### PR TITLE
🍴 disabling Grafana operator on phobos, as it eats up a lot of CPU on the gitops app... ;)

### DIFF
--- a/manifests/environments/phobos/kustomization.yaml
+++ b/manifests/environments/phobos/kustomization.yaml
@@ -15,7 +15,7 @@ resources:
 
   - cert-manager-operator/
 
-  - grafana-operator/
+  # - grafana-operator/
   - crunchy-postgres/
 
   - default-ingress-certificate.yaml


### PR DESCRIPTION
Signed-off-by: Christoph Görn <goern@b4mad.net>
