### PR TITLE
build: automatic update of prow

### DIFF
--- a/manifests/applications/prow/kustomization.yaml
+++ b/manifests/applications/prow/kustomization.yaml
@@ -80,7 +80,7 @@ images:
 - name: gcr.io/k8s-prow/branchprotector
   newTag: v20230930-5a0076ef61
 - name: gcr.io/k8s-prow/crier
-  newTag: v20230927-f8b8856dbc
+  newTag: v20230930-5a0076ef61
 - name: gcr.io/k8s-prow/deck
   newTag: v20230930-5a0076ef61
 - name: gcr.io/k8s-prow/ghproxy


### PR DESCRIPTION
updates image k8s-prow/branchprotector tag 'v20230901-e9e5d470a5' to 'v20230930-5a0076ef61' updates image k8s-prow/crier tag 'v20230927-f8b8856dbc' to 'v20230930-5a0076ef61'