### PR TITLE
build: automatic update of prow

### DIFF
--- a/manifests/applications/prow/kustomization.yaml
+++ b/manifests/applications/prow/kustomization.yaml
@@ -78,24 +78,24 @@ images:
   newName: gcr.io/k8s-prow/crier
   newTag: v20230801-526a7e0f2c
 - name: gcr.io/k8s-prow/branchprotector
-  newTag: v20230930-5a0076ef61
+  newTag: v20231003-e23b6604b5
 - name: gcr.io/k8s-prow/crier
-  newTag: v20230930-5a0076ef61
+  newTag: v20231003-e23b6604b5
 - name: gcr.io/k8s-prow/deck
-  newTag: v20230930-5a0076ef61
+  newTag: v20231003-e23b6604b5
 - name: gcr.io/k8s-prow/ghproxy
-  newTag: v20230930-5a0076ef61
+  newTag: v20231003-e23b6604b5
 - name: gcr.io/k8s-prow/hook
-  newTag: v20230930-5a0076ef61
+  newTag: v20231003-e23b6604b5
 - name: gcr.io/k8s-prow/horologium
-  newTag: v20230930-5a0076ef61
+  newTag: v20231003-e23b6604b5
 - name: gcr.io/k8s-prow/needs-rebase
-  newTag: v20230930-5a0076ef61
+  newTag: v20231003-e23b6604b5
 - name: gcr.io/k8s-prow/prow-controller-manager
-  newTag: v20230930-5a0076ef61
+  newTag: v20231003-e23b6604b5
 - name: gcr.io/k8s-prow/sinker
-  newTag: v20230930-5a0076ef61
+  newTag: v20231003-e23b6604b5
 - name: gcr.io/k8s-prow/status-reconciler
-  newTag: v20230930-5a0076ef61
+  newTag: v20231003-e23b6604b5
 - name: gcr.io/k8s-prow/tide
-  newTag: v20230930-5a0076ef61
+  newTag: v20231003-e23b6604b5


### PR DESCRIPTION
updates image k8s-prow/branchprotector tag 'v20230930-5a0076ef61' to 'v20231003-e23b6604b5' updates image k8s-prow/crier tag 'v20230930-5a0076ef61' to 'v20231003-e23b6604b5' updates image k8s-prow/deck tag 'v20230930-5a0076ef61' to 'v20231003-e23b6604b5' updates image k8s-prow/ghproxy tag 'v20230930-5a0076ef61' to 'v20231003-e23b6604b5' updates image k8s-prow/hook tag 'v20230930-5a0076ef61' to 'v20231003-e23b6604b5' updates image k8s-prow/horologium tag 'v20230930-5a0076ef61' to 'v20231003-e23b6604b5' updates image k8s-prow/needs-rebase tag 'v20230930-5a0076ef61' to 'v20231003-e23b6604b5' updates image k8s-prow/prow-controller-manager tag 'v20230930-5a0076ef61' to 'v20231003-e23b6604b5' updates image k8s-prow/sinker tag 'v20230930-5a0076ef61' to 'v20231003-e23b6604b5' updates image k8s-prow/status-reconciler tag 'v20230930-5a0076ef61' to 'v20231003-e23b6604b5' updates image k8s-prow/tide tag 'v20230930-5a0076ef61' to 'v20231003-e23b6604b5'