### PR TITLE
build: automatic update of prow

### DIFF
--- a/manifests/applications/prow/kustomization.yaml
+++ b/manifests/applications/prow/kustomization.yaml
@@ -4,98 +4,98 @@ commonLabels:
   app.kubernetes.io/name: prow
   app.kubernetes.io/managed-by: op1st-emea-b4mad
 resources:
-  - namespaces.yaml
-  - customresourcedefinition.yaml
-  - branchprotector.yaml
-  - label-sync.yaml
-  - ingress.yaml
-  - crier/
-  - deck/
-  - ghproxy/
-  - hook/
-  - horologium/
-  - needs-rebase/
-  - pipeline/
-  - prow-controller-manager/
-  - service_monitors.yaml
-  - sinker/
-  - statusreconciler/
-  - tide/
-  - secrets/cookie.yaml
-  - secrets/github-oauth-config.yaml
-  - secrets/github-token-test-pods.yaml
-  - secrets/github-token.yaml
-  - secrets/hmac-token.yaml
-  - secrets/oauth-token-test-pods.yaml
-  - secrets/oauth-token.yaml
-  - secrets/s3-credentials-test-pods.yaml
-  - secrets/s3-credentials.yaml
+- namespaces.yaml
+- customresourcedefinition.yaml
+- branchprotector.yaml
+- label-sync.yaml
+- ingress.yaml
+- crier/
+- deck/
+- ghproxy/
+- hook/
+- horologium/
+- needs-rebase/
+- pipeline/
+- prow-controller-manager/
+- service_monitors.yaml
+- sinker/
+- statusreconciler/
+- tide/
+- secrets/cookie.yaml
+- secrets/github-oauth-config.yaml
+- secrets/github-token-test-pods.yaml
+- secrets/github-token.yaml
+- secrets/hmac-token.yaml
+- secrets/oauth-token-test-pods.yaml
+- secrets/oauth-token.yaml
+- secrets/s3-credentials-test-pods.yaml
+- secrets/s3-credentials.yaml
 configMapGenerator:
-  - name: config
-    files:
-      - config.yaml
-  - name: plugins
-    files:
-      - plugins.yaml
+- name: config
+  files:
+  - config.yaml
+- name: plugins
+  files:
+  - plugins.yaml
 images:
-  - name: tide
-    newName: gcr.io/k8s-prow/tide
-    newTag: v20231011-acf4a2e26b
-  - name: branchprotector
-    newName: gcr.io/k8s-prow/branchprotector
-    newTag: v20231011-acf4a2e26b
-  - name: label_sync
-    newName: gcr.io/k8s-prow/label_sync
-    newTag: v20231011-acf4a2e26b
-  - name: status-reconciler
-    newName: gcr.io/k8s-prow/status-reconciler
-    newTag: v20231011-acf4a2e26b
-  - name: sinker
-    newName: gcr.io/k8s-prow/sinker
-    newTag: v20231011-acf4a2e26b
-  - name: prow-controller-manager
-    newName: gcr.io/k8s-prow/prow-controller-manager
-    newTag: v20231011-acf4a2e26b
-  - name: pipeline
-    newName: gcr.io/k8s-prow/pipeline
-    newTag: v20231011-acf4a2e26b
-  - name: needs-rebase
-    newName: gcr.io/k8s-prow/needs-rebase
-    newTag: v20231011-acf4a2e26b
-  - name: horologium
-    newName: gcr.io/k8s-prow/horologium
-    newTag: v20231011-acf4a2e26b
-  - name: hook
-    newName: gcr.io/k8s-prow/hook
-    newTag: v20231011-acf4a2e26b
-  - name: ghproxy
-    newName: gcr.io/k8s-prow/ghproxy
-    newTag: v20231011-acf4a2e26b
-  - name: deck
-    newName: gcr.io/k8s-prow/deck
-    newTag: v20231011-acf4a2e26b
-  - name: crier
-    newName: gcr.io/k8s-prow/crier
-    newTag: v20231011-acf4a2e26b
-  - name: gcr.io/k8s-prow/branchprotector
-    newTag: v20231011-acf4a2e26b
-  - name: gcr.io/k8s-prow/crier
-    newTag: v20231011-acf4a2e26b
-  - name: gcr.io/k8s-prow/deck
-    newTag: v20231011-acf4a2e26b
-  - name: gcr.io/k8s-prow/ghproxy
-    newTag: v20231011-acf4a2e26b
-  - name: gcr.io/k8s-prow/hook
-    newTag: v20231011-acf4a2e26b
-  - name: gcr.io/k8s-prow/horologium
-    newTag: v20231011-acf4a2e26b
-  - name: gcr.io/k8s-prow/needs-rebase
-    newTag: v20231011-acf4a2e26b
-  - name: gcr.io/k8s-prow/prow-controller-manager
-    newTag: v20231011-acf4a2e26b
-  - name: gcr.io/k8s-prow/sinker
-    newTag: v20231011-acf4a2e26b
-  - name: gcr.io/k8s-prow/status-reconciler
-    newTag: v20231011-acf4a2e26b
-  - name: gcr.io/k8s-prow/tide
-    newTag: v20231011-acf4a2e26b
+- name: tide
+  newName: gcr.io/k8s-prow/tide
+  newTag: v20231011-acf4a2e26b
+- name: branchprotector
+  newName: gcr.io/k8s-prow/branchprotector
+  newTag: v20231011-acf4a2e26b
+- name: label_sync
+  newName: gcr.io/k8s-prow/label_sync
+  newTag: v20231011-acf4a2e26b
+- name: status-reconciler
+  newName: gcr.io/k8s-prow/status-reconciler
+  newTag: v20231011-acf4a2e26b
+- name: sinker
+  newName: gcr.io/k8s-prow/sinker
+  newTag: v20231011-acf4a2e26b
+- name: prow-controller-manager
+  newName: gcr.io/k8s-prow/prow-controller-manager
+  newTag: v20231011-acf4a2e26b
+- name: pipeline
+  newName: gcr.io/k8s-prow/pipeline
+  newTag: v20231011-acf4a2e26b
+- name: needs-rebase
+  newName: gcr.io/k8s-prow/needs-rebase
+  newTag: v20231011-acf4a2e26b
+- name: horologium
+  newName: gcr.io/k8s-prow/horologium
+  newTag: v20231011-acf4a2e26b
+- name: hook
+  newName: gcr.io/k8s-prow/hook
+  newTag: v20231011-acf4a2e26b
+- name: ghproxy
+  newName: gcr.io/k8s-prow/ghproxy
+  newTag: v20231011-acf4a2e26b
+- name: deck
+  newName: gcr.io/k8s-prow/deck
+  newTag: v20231011-acf4a2e26b
+- name: crier
+  newName: gcr.io/k8s-prow/crier
+  newTag: v20231011-acf4a2e26b
+- name: gcr.io/k8s-prow/branchprotector
+  newTag: v20231019-811baf28f3
+- name: gcr.io/k8s-prow/crier
+  newTag: v20231019-811baf28f3
+- name: gcr.io/k8s-prow/deck
+  newTag: v20231019-811baf28f3
+- name: gcr.io/k8s-prow/ghproxy
+  newTag: v20231019-811baf28f3
+- name: gcr.io/k8s-prow/hook
+  newTag: v20231019-811baf28f3
+- name: gcr.io/k8s-prow/horologium
+  newTag: v20231019-811baf28f3
+- name: gcr.io/k8s-prow/needs-rebase
+  newTag: v20231019-811baf28f3
+- name: gcr.io/k8s-prow/prow-controller-manager
+  newTag: v20231019-811baf28f3
+- name: gcr.io/k8s-prow/sinker
+  newTag: v20231019-811baf28f3
+- name: gcr.io/k8s-prow/status-reconciler
+  newTag: v20231019-811baf28f3
+- name: gcr.io/k8s-prow/tide
+  newTag: v20231019-811baf28f3


### PR DESCRIPTION
updates image k8s-prow/branchprotector tag 'v20231011-acf4a2e26b' to 'v20231019-811baf28f3' updates image k8s-prow/crier tag 'v20231011-acf4a2e26b' to 'v20231019-811baf28f3' updates image k8s-prow/deck tag 'v20231011-acf4a2e26b' to 'v20231019-811baf28f3' updates image k8s-prow/ghproxy tag 'v20231011-acf4a2e26b' to 'v20231019-811baf28f3' updates image k8s-prow/hook tag 'v20231011-acf4a2e26b' to 'v20231019-811baf28f3' updates image k8s-prow/horologium tag 'v20231011-acf4a2e26b' to 'v20231019-811baf28f3' updates image k8s-prow/needs-rebase tag 'v20231011-acf4a2e26b' to 'v20231019-811baf28f3' updates image k8s-prow/prow-controller-manager tag 'v20231011-acf4a2e26b' to 'v20231019-811baf28f3' updates image k8s-prow/sinker tag 'v20231011-acf4a2e26b' to 'v20231019-811baf28f3' updates image k8s-prow/status-reconciler tag 'v20231011-acf4a2e26b' to 'v20231019-811baf28f3' updates image k8s-prow/tide tag 'v20231011-acf4a2e26b' to 'v20231019-811baf28f3'