### PR TITLE
build: automatic update of prow

### DIFF
--- a/manifests/applications/prow/kustomization.yaml
+++ b/manifests/applications/prow/kustomization.yaml
@@ -78,24 +78,24 @@ images:
   newName: gcr.io/k8s-prow/crier
   newTag: v20231011-acf4a2e26b
 - name: gcr.io/k8s-prow/branchprotector
-  newTag: v20231027-9cda73bb73
+  newTag: v20231101-174189c793
 - name: gcr.io/k8s-prow/crier
-  newTag: v20231027-9cda73bb73
+  newTag: v20231101-174189c793
 - name: gcr.io/k8s-prow/deck
   newTag: v20231027-9cda73bb73
 - name: gcr.io/k8s-prow/ghproxy
-  newTag: v20231027-9cda73bb73
+  newTag: v20231101-174189c793
 - name: gcr.io/k8s-prow/hook
-  newTag: v20231027-9cda73bb73
+  newTag: v20231101-174189c793
 - name: gcr.io/k8s-prow/horologium
-  newTag: v20231027-9cda73bb73
+  newTag: v20231101-174189c793
 - name: gcr.io/k8s-prow/needs-rebase
-  newTag: v20231027-9cda73bb73
+  newTag: v20231101-174189c793
 - name: gcr.io/k8s-prow/prow-controller-manager
-  newTag: v20231027-9cda73bb73
+  newTag: v20231101-174189c793
 - name: gcr.io/k8s-prow/sinker
-  newTag: v20231027-9cda73bb73
+  newTag: v20231101-174189c793
 - name: gcr.io/k8s-prow/status-reconciler
-  newTag: v20231027-9cda73bb73
+  newTag: v20231101-174189c793
 - name: gcr.io/k8s-prow/tide
-  newTag: v20231027-9cda73bb73
+  newTag: v20231101-174189c793


### PR DESCRIPTION
updates image k8s-prow/branchprotector tag 'v20231027-9cda73bb73' to 'v20231101-174189c793' updates image k8s-prow/crier tag 'v20231027-9cda73bb73' to 'v20231101-174189c793' updates image k8s-prow/ghproxy tag 'v20231027-9cda73bb73' to 'v20231101-174189c793' updates image k8s-prow/hook tag 'v20231027-9cda73bb73' to 'v20231101-174189c793' updates image k8s-prow/horologium tag 'v20231027-9cda73bb73' to 'v20231101-174189c793' updates image k8s-prow/needs-rebase tag 'v20231027-9cda73bb73' to 'v20231101-174189c793' updates image k8s-prow/prow-controller-manager tag 'v20231027-9cda73bb73' to 'v20231101-174189c793' updates image k8s-prow/sinker tag 'v20231027-9cda73bb73' to 'v20231101-174189c793' updates image k8s-prow/status-reconciler tag 'v20231027-9cda73bb73' to 'v20231101-174189c793' updates image k8s-prow/tide tag 'v20231027-9cda73bb73' to 'v20231101-174189c793'