### PR TITLE
build: automatic update of prow

### DIFF
--- a/manifests/applications/prow/kustomization.yaml
+++ b/manifests/applications/prow/kustomization.yaml
@@ -78,24 +78,24 @@ images:
   newName: gcr.io/k8s-prow/crier
   newTag: v20231011-acf4a2e26b
 - name: gcr.io/k8s-prow/branchprotector
-  newTag: v20231103-74dcf8db5c
+  newTag: v20231127-6bd5ce71de
 - name: gcr.io/k8s-prow/crier
-  newTag: v20231114-9e6076d23d
+  newTag: v20231127-6bd5ce71de
 - name: gcr.io/k8s-prow/deck
-  newTag: v20231114-9e6076d23d
+  newTag: v20231127-6bd5ce71de
 - name: gcr.io/k8s-prow/ghproxy
-  newTag: v20231114-9e6076d23d
+  newTag: v20231127-6bd5ce71de
 - name: gcr.io/k8s-prow/hook
-  newTag: v20231114-9e6076d23d
+  newTag: v20231127-6bd5ce71de
 - name: gcr.io/k8s-prow/horologium
-  newTag: v20231114-9e6076d23d
+  newTag: v20231127-6bd5ce71de
 - name: gcr.io/k8s-prow/needs-rebase
-  newTag: v20231114-9e6076d23d
+  newTag: v20231127-6bd5ce71de
 - name: gcr.io/k8s-prow/prow-controller-manager
-  newTag: v20231114-9e6076d23d
+  newTag: v20231127-6bd5ce71de
 - name: gcr.io/k8s-prow/sinker
-  newTag: v20231114-9e6076d23d
+  newTag: v20231127-6bd5ce71de
 - name: gcr.io/k8s-prow/status-reconciler
-  newTag: v20231114-9e6076d23d
+  newTag: v20231127-6bd5ce71de
 - name: gcr.io/k8s-prow/tide
-  newTag: v20231114-9e6076d23d
+  newTag: v20231127-6bd5ce71de


### PR DESCRIPTION
updates image k8s-prow/branchprotector tag 'v20231103-74dcf8db5c' to 'v20231127-6bd5ce71de' updates image k8s-prow/crier tag 'v20231114-9e6076d23d' to 'v20231127-6bd5ce71de' updates image k8s-prow/deck tag 'v20231114-9e6076d23d' to 'v20231127-6bd5ce71de' updates image k8s-prow/ghproxy tag 'v20231114-9e6076d23d' to 'v20231127-6bd5ce71de' updates image k8s-prow/hook tag 'v20231114-9e6076d23d' to 'v20231127-6bd5ce71de' updates image k8s-prow/horologium tag 'v20231114-9e6076d23d' to 'v20231127-6bd5ce71de' updates image k8s-prow/needs-rebase tag 'v20231114-9e6076d23d' to 'v20231127-6bd5ce71de' updates image k8s-prow/prow-controller-manager tag 'v20231114-9e6076d23d' to 'v20231127-6bd5ce71de' updates image k8s-prow/sinker tag 'v20231114-9e6076d23d' to 'v20231127-6bd5ce71de' updates image k8s-prow/status-reconciler tag 'v20231114-9e6076d23d' to 'v20231127-6bd5ce71de' updates image k8s-prow/tide tag 'v20231114-9e6076d23d' to 'v20231127-6bd5ce71de'