### PR TITLE
build: automatic update of prow

### DIFF
--- a/manifests/applications/prow/kustomization.yaml
+++ b/manifests/applications/prow/kustomization.yaml
@@ -78,24 +78,24 @@ images:
   newName: gcr.io/k8s-prow/crier
   newTag: v20231011-acf4a2e26b
 - name: gcr.io/k8s-prow/branchprotector
-  newTag: v20231127-6bd5ce71de
+  newTag: v20231213-380b89a158
 - name: gcr.io/k8s-prow/crier
-  newTag: v20231127-6bd5ce71de
+  newTag: v20231213-380b89a158
 - name: gcr.io/k8s-prow/deck
-  newTag: v20231127-6bd5ce71de
+  newTag: v20231213-380b89a158
 - name: gcr.io/k8s-prow/ghproxy
-  newTag: v20231127-6bd5ce71de
+  newTag: v20231213-380b89a158
 - name: gcr.io/k8s-prow/hook
-  newTag: v20231127-6bd5ce71de
+  newTag: v20231213-380b89a158
 - name: gcr.io/k8s-prow/horologium
-  newTag: v20231127-6bd5ce71de
+  newTag: v20231213-380b89a158
 - name: gcr.io/k8s-prow/needs-rebase
-  newTag: v20231127-6bd5ce71de
+  newTag: v20231213-380b89a158
 - name: gcr.io/k8s-prow/prow-controller-manager
-  newTag: v20231127-6bd5ce71de
+  newTag: v20231213-380b89a158
 - name: gcr.io/k8s-prow/sinker
-  newTag: v20231127-6bd5ce71de
+  newTag: v20231213-380b89a158
 - name: gcr.io/k8s-prow/status-reconciler
-  newTag: v20231127-6bd5ce71de
+  newTag: v20231213-380b89a158
 - name: gcr.io/k8s-prow/tide
-  newTag: v20231127-6bd5ce71de
+  newTag: v20231213-380b89a158


### PR DESCRIPTION
updates image k8s-prow/branchprotector tag 'v20231127-6bd5ce71de' to 'v20231213-380b89a158' updates image k8s-prow/crier tag 'v20231127-6bd5ce71de' to 'v20231213-380b89a158' updates image k8s-prow/deck tag 'v20231127-6bd5ce71de' to 'v20231213-380b89a158' updates image k8s-prow/ghproxy tag 'v20231127-6bd5ce71de' to 'v20231213-380b89a158' updates image k8s-prow/hook tag 'v20231127-6bd5ce71de' to 'v20231213-380b89a158' updates image k8s-prow/horologium tag 'v20231127-6bd5ce71de' to 'v20231213-380b89a158' updates image k8s-prow/needs-rebase tag 'v20231127-6bd5ce71de' to 'v20231213-380b89a158' updates image k8s-prow/prow-controller-manager tag 'v20231127-6bd5ce71de' to 'v20231213-380b89a158' updates image k8s-prow/sinker tag 'v20231127-6bd5ce71de' to 'v20231213-380b89a158' updates image k8s-prow/status-reconciler tag 'v20231127-6bd5ce71de' to 'v20231213-380b89a158' updates image k8s-prow/tide tag 'v20231127-6bd5ce71de' to 'v20231213-380b89a158'