### PR TITLE
feat: Deploy B4mad DAO off-chain tooling on Nostromo

### DIFF
--- a/manifests/applications/b4mad-dao.yaml
+++ b/manifests/applications/b4mad-dao.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: b4mad-dao
+spec:
+  destination:
+    name: in-cluster
+    namespace: b4mad-dao
+  project: op1st
+  source:
+    path: manifests/applications/b4mad-dao
+    repoURL: https://github.com/b4mad/op1st-emea-b4mad
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+    retry:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m0s
+      limit: 2

--- a/manifests/applications/b4mad-dao.yaml
+++ b/manifests/applications/b4mad-dao.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   destination:
     name: in-cluster
-    namespace: b4mad-dao
+    namespace: b4mad-dao-testnet
   project: op1st
   source:
     path: manifests/applications/b4mad-dao

--- a/manifests/applications/b4mad-dao/configmap.yaml
+++ b/manifests/applications/b4mad-dao/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dao-config
+data:
+  BASE_SEPOLIA_RPC_URL: "https://sepolia.base.org"
+  NETWORK: "baseSepolia"
+  # Contract addresses - update after deployment
+  # B4MAD_TOKEN_ADDRESS: ""
+  # GOVERNOR_ADDRESS: ""
+  # TIMELOCK_ADDRESS: ""

--- a/manifests/applications/b4mad-dao/cronjob.yaml
+++ b/manifests/applications/b4mad-dao/cronjob.yaml
@@ -1,0 +1,36 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: dao-governance
+spec:
+  schedule: "0 */6 * * *"  # Every 6 hours
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 600
+      template:
+        spec:
+          restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            fsGroup: 1001
+          containers:
+            - name: dao-governance
+              image: b4mad-dao-contracts
+              command: ["node", "scripts/e2e-governance.mjs"]
+              envFrom:
+                - configMapRef:
+                    name: dao-config
+                - secretRef:
+                    name: dao-deployer-key
+              resources:
+                requests:
+                  memory: "256Mi"
+                  cpu: "100m"
+                limits:
+                  memory: "512Mi"
+                  cpu: "500m"

--- a/manifests/applications/b4mad-dao/kustomization.yaml
+++ b/manifests/applications/b4mad-dao/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: b4mad-dao
+
+labels:
+  - pairs:
+      app.kubernetes.io/name: dao
+      app.kubernetes.io/component: governance-tooling
+      app.kubernetes.io/instance: nostromo
+      app.kubernetes.io/managed-by: op1st-emea-b4mad
+    includeTemplates: true
+
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - secret-deployer-key.yaml
+  - cronjob.yaml
+
+images:
+  - name: b4mad-dao-contracts
+    newName: ghcr.io/brenner-axiom/b4mad-dao-contracts
+    newTag: latest

--- a/manifests/applications/b4mad-dao/kustomization.yaml
+++ b/manifests/applications/b4mad-dao/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: b4mad-dao
+namespace: b4mad-dao-testnet
 
 labels:
   - pairs:

--- a/manifests/applications/b4mad-dao/namespace.yaml
+++ b/manifests/applications/b4mad-dao/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: b4mad-dao
+  labels:
+    app.kubernetes.io/name: dao
+    app.kubernetes.io/part-of: b4mad

--- a/manifests/applications/b4mad-dao/namespace.yaml
+++ b/manifests/applications/b4mad-dao/namespace.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: b4mad-dao
+  name: b4mad-dao-testnet
   labels:
     app.kubernetes.io/name: dao
     app.kubernetes.io/part-of: b4mad

--- a/manifests/applications/b4mad-dao/secret-deployer-key.yaml
+++ b/manifests/applications/b4mad-dao/secret-deployer-key.yaml
@@ -2,16 +2,14 @@ apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 metadata:
   name: dao-deployer-key
-  namespace: b4mad-dao
   annotations:
     sealedsecrets.bitnami.com/managed: "true"
 spec:
   encryptedData:
     # TODO: Seal the deployer private key using kubeseal against the Nostromo cluster
-    # Run: echo -n "$(gopass show openclaw/dao-deployer)" | kubeseal --raw --namespace b4mad-dao --name dao-deployer-key --from-file=/dev/stdin
+    # Run: echo -n "$(gopass show openclaw/dao-deployer)" | kubeseal --raw --namespace b4mad-dao-testnet --name dao-deployer-key --from-file=/dev/stdin
     PRIVATE_KEY: PLACEHOLDER_NEEDS_SEALING
   template:
     metadata:
       name: dao-deployer-key
-      namespace: b4mad-dao
     type: Opaque

--- a/manifests/applications/b4mad-dao/secret-deployer-key.yaml
+++ b/manifests/applications/b4mad-dao/secret-deployer-key.yaml
@@ -1,0 +1,17 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: dao-deployer-key
+  namespace: b4mad-dao
+  annotations:
+    sealedsecrets.bitnami.com/managed: "true"
+spec:
+  encryptedData:
+    # TODO: Seal the deployer private key using kubeseal against the Nostromo cluster
+    # Run: echo -n "$(gopass show openclaw/dao-deployer)" | kubeseal --raw --namespace b4mad-dao --name dao-deployer-key --from-file=/dev/stdin
+    PRIVATE_KEY: PLACEHOLDER_NEEDS_SEALING
+  template:
+    metadata:
+      name: dao-deployer-key
+      namespace: b4mad-dao
+    type: Opaque

--- a/manifests/applications/kustomization.yaml
+++ b/manifests/applications/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
   - environment-phobos.yaml
   - op1st-gitops.yaml
   - op1st-pipelines.yaml
+  - b4mad-dao.yaml


### PR DESCRIPTION
## Summary

Deploys the #B4mad DAO off-chain governance tooling on the Nostromo OpenShift cluster via GitOps.

### What's included

- **ArgoCD Application** (`b4mad-dao.yaml`) pointing to `manifests/applications/b4mad-dao/`
- **Namespace** `b4mad-dao`
- **CronJob** `dao-governance` — runs `node scripts/e2e-governance.mjs` every 6 hours
- **ConfigMap** with Base Sepolia RPC URL configuration
- **SealedSecret placeholder** for the deployer private key (needs `kubeseal` against Nostromo)
- **Container image** pushed to `ghcr.io/brenner-axiom/b4mad-dao-contracts:latest`

### Before merging — action required

1. **Seal the deployer key**: Run `kubeseal` against Nostromo to encrypt the deployer private key and replace the placeholder in `secret-deployer-key.yaml`
2. **Create `scripts/e2e-governance.mjs`** in the DAO contracts repo — the CronJob references this script but it doesn't exist yet
3. **Update contract addresses** in the ConfigMap once deployed

### Bead
`beads-hub-bfq` — DAO: Deploy #B4mad DAO stack on Nostromo OpenShift cluster