### PR TITLE
feat(nostromo): scrape the erd/G/eschoss Meshtastic gateway

### DIFF
--- a/manifests/applications/b4mad-meshtastic-gateway/kustomization.yaml
+++ b/manifests/applications/b4mad-meshtastic-gateway/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: b4mad-meshtastic-gateway
+
+labels:
+  # includeSelectors=false is required: the Service is selectorless (external
+  # target via manually-managed Endpoints), and injecting a selector would cause
+  # the endpoints controller to overwrite it with empty pod endpoints.
+  - includeSelectors: false
+    pairs:
+      app.kubernetes.io/name: meshtastic-gateway
+      app.kubernetes.io/managed-by: op1st-emea-b4mad
+
+resources:
+  - namespace.yaml
+  - service.yaml
+  - monitoring.yaml

--- a/manifests/applications/b4mad-meshtastic-gateway/monitoring.yaml
+++ b/manifests/applications/b4mad-meshtastic-gateway/monitoring.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: meshtastic-gateway
+spec:
+  endpoints:
+    - path: /metrics
+      port: metrics
+      interval: 30s
+      scheme: http
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: meshtastic-gateway
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: meshtastic-gateway
+  labels:
+    openshift.io/prometheus-rule-evaluation-scope: leaf-prometheus
+spec:
+  groups:
+    - name: meshtastic-gateway
+      rules:
+        - alert: MeshtasticGatewayDown
+          for: 5m
+          expr: up{service="meshtastic-gateway"} == 0
+          labels:
+            severity: warning
+          annotations:
+            summary: erd/G/eschoss Meshtastic gateway (#B4mad.Net) is unreachable
+            description: Prometheus has been unable to scrape the meshtastic-gateway for the erd/G/eschoss node at {{ $labels.instance }} for >= 5 minutes.
+        - alert: MeshtasticMQTTDisconnected
+          for: 10m
+          expr: meshtastic_mqtt_connected == 0
+          labels:
+            severity: warning
+          annotations:
+            summary: erd/G/eschoss Meshtastic gateway (#B4mad.Net) has lost MQTT
+            description: The erd/G/eschoss gateway at {{ $labels.instance }} has reported mqtt_connected=0 for >= 10 minutes; it is no longer bridging the #B4mad.Net node to the Meshtastic MQTT broker.

--- a/manifests/applications/b4mad-meshtastic-gateway/namespace.yaml
+++ b/manifests/applications/b4mad-meshtastic-gateway/namespace.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/display-name: "Meshtastic gateway — erd/G/eschoss (#B4mad.Net)"
+    openshift.io/description: "Scrape target for the erd/G/eschoss Meshtastic node on the #B4mad.Net Network. The physical node is tethered via USB to the rpi5 host at Erdgeschoss; its long name is 'erdGeschoss' (short: 'b4eg'), operating on EU_868."
+    openshift.io/cluster-monitoring: "true"
+  labels:
+    b4mad.operate-first.cloud/owner: goern.b4mad.net
+  name: b4mad-meshtastic-gateway

--- a/manifests/applications/b4mad-meshtastic-gateway/service.yaml
+++ b/manifests/applications/b4mad-meshtastic-gateway/service.yaml
@@ -1,0 +1,32 @@
+---
+# Selectorless Service + manually-managed Endpoints — the Prometheus-operator
+# idiom for scraping an out-of-cluster target via a ServiceMonitor. The Endpoints
+# object points at the meshtastic-gateway /metrics port on the rpi5 host at
+# Erdgeschoss, which tethers the 'erdGeschoss' Meshtastic node of the
+# #B4mad.Net Network.
+apiVersion: v1
+kind: Service
+metadata:
+  name: meshtastic-gateway
+  labels:
+    app.kubernetes.io/name: meshtastic-gateway
+spec:
+  ports:
+    - name: metrics
+      port: 9464
+      targetPort: 9464
+      protocol: TCP
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: meshtastic-gateway
+  labels:
+    app.kubernetes.io/name: meshtastic-gateway
+subsets:
+  - addresses:
+      - ip: 192.168.0.75
+    ports:
+      - name: metrics
+        port: 9464
+        protocol: TCP

--- a/manifests/applications/op1st-gitops/applications/b4mad-meshtastic-gateway.yaml
+++ b/manifests/applications/op1st-gitops/applications/b4mad-meshtastic-gateway.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: b4mad-meshtastic-gateway
+  namespace: op1st-gitops
+spec:
+  destination:
+    namespace: b4mad-meshtastic-gateway
+    server: https://api.nostromo.erdgeschoss.b4mad.emea.operate-first.cloud:6443
+  project: b4mad
+  source:
+    path: manifests/applications/b4mad-meshtastic-gateway
+    repoURL: https://github.com/b4mad/op1st-emea-b4mad
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/manifests/applications/op1st-gitops/kustomization.yaml
+++ b/manifests/applications/op1st-gitops/kustomization.yaml
@@ -20,6 +20,7 @@ resources:
   - repositories/
 
   - applications/b4mad-keycloak.yaml
+  - applications/b4mad-meshtastic-gateway.yaml
   - applications/b4mad-racing.yaml
   - applications/b4mad-radicle.yaml
   - applications/b4mad-renovate.yaml


### PR DESCRIPTION
Scrape the meshtastic-gateway /metrics endpoint at Erdgeschoss (rpi5, 192.168.0.75:9464) from nostromo's user-workload Prometheus. The host rpi5 tethers the 'erdGeschoss' Meshtastic node (short: 'b4eg', EU_868) of the #B4mad.Net Network and bridges it to MQTT.

Adds a selectorless Service + manually-managed Endpoints, a ServiceMonitor, and a PrometheusRule with MeshtasticGatewayDown (scrape target unreachable >= 5m) and MeshtasticMQTTDisconnected (MQTT bridge down >= 10m), both severity=warning. Wired in as a new Argo Application under the b4mad AppProject (the op1st project's 'op1st-*' namespace scope doesn't permit 'b4mad-meshtastic-gateway').

Uses the modern 'labels: includeSelectors=false' kustomize form rather than deprecated 'commonLabels'; the latter silently injects labels into spec.selector on Services, which would cause the endpoints controller to overwrite the manually-managed Endpoints with empty ones and break the scrape at runtime with no apply-time error.