### PR TITLE
feat(nostromo): epaper-service Argo Application

### DIFF
--- a/manifests/applications/epaper-service.yaml
+++ b/manifests/applications/epaper-service.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2026 Christoph Görn <goern@b4mad.net>
+# SPDX-License-Identifier: GPL-3.0-or-later
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: epaper-service
+  namespace: openshift-gitops
+spec:
+  project: b4mad
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: b4mad-epaper-service
+  source:
+    repoURL: https://codeberg.org/goern/epaper-service
+    targetRevision: main
+    path: manifests
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true


### PR DESCRIPTION
## Summary

Adds the ArgoCD bootstrap pointing at `codeberg.org/goern/epaper-service`. The application repo is a brand-new standalone service that renders 1-bit 250x122 images for the rpi02w Waveshare 2.13\" V4 e-paper panel. Image tag pinned in the source repo's `manifests/kustomization.yaml`; future releases land via main updates only.

Service contract: bearer-token writes, public reads, FastAPI auto-OpenAPI at `/openapi.json`. Plug-in scenes (logo + message in v1).

## Test plan

- [ ] After merge, ArgoCD app `epaper-service` reaches `Synced` / `Healthy`
- [ ] `oc -n b4mad-epaper-service get all` shows the deployment + service + route
- [ ] `curl https://<route-host>/healthz` returns `{\"status\":\"ok\"}`
- [ ] Prometheus user-workload monitoring shows `up{service=\"epaper-service\"}=1`