### PR TITLE
fix(nostromo): register epaper-service Application in app-of-apps

### DIFF
--- a/manifests/applications/kustomization.yaml
+++ b/manifests/applications/kustomization.yaml
@@ -11,5 +11,6 @@ resources:
   - environment-nostromo.yaml
   # - nostromo-gatekeeper.yaml
   - environment-phobos.yaml
+  - epaper-service.yaml
   - op1st-gitops.yaml
   - op1st-pipelines.yaml


### PR DESCRIPTION
## Summary

PR #76 added `manifests/applications/epaper-service.yaml` but did not register it in `manifests/applications/kustomization.yaml`. The `app-of-apps` ArgoCD Application uses Kustomize with an explicit `resources:` list, so the unlisted file was silently ignored — the `epaper-service` Application was never created on `nostromo` and the `b4mad-epaper-service` namespace stayed empty.

This PR adds the single line that registers it.

## Test plan

- [ ] After merge, `oc -n openshift-gitops get application epaper-service` returns Synced/Healthy
- [ ] `oc -n b4mad-epaper-service get all` shows deployment + service + route
- [ ] `curl https://<route>/healthz` returns `{"status":"ok"}`