### PR TITLE
feat(nostromo): move epaper-service Application under op1st-gitops

### DIFF
--- a/manifests/applications/kustomization.yaml
+++ b/manifests/applications/kustomization.yaml
@@ -11,6 +11,5 @@ resources:
   - environment-nostromo.yaml
   # - nostromo-gatekeeper.yaml
   - environment-phobos.yaml
-  - epaper-service.yaml
   - op1st-gitops.yaml
   - op1st-pipelines.yaml

--- a/manifests/applications/op1st-gitops/applications/epaper-service.yaml
+++ b/manifests/applications/op1st-gitops/applications/epaper-service.yaml
@@ -4,12 +4,12 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: epaper-service
-  namespace: openshift-gitops
+  namespace: op1st-gitops
 spec:
-  project: b4mad
   destination:
-    server: https://kubernetes.default.svc
     namespace: b4mad-epaper-service
+    server: https://api.nostromo.erdgeschoss.b4mad.emea.operate-first.cloud:6443
+  project: b4mad
   source:
     repoURL: https://codeberg.org/goern/epaper-service
     targetRevision: main


### PR DESCRIPTION
## Summary

End-user services on nostromo (`b4mad-meshtastic-gateway`, `b4mad-keycloak`, `b4mad-radicle`, etc.) live under `manifests/applications/op1st-gitops/applications/`, scoped to the `b4mad` AppProject. The `epaper-service` Application was originally registered at the top-level app-of-apps (PRs #76 + #77), which is reserved for cluster-management infrastructure.

This PR relocates the Application to match the existing pattern.

Diff:
- Move `manifests/applications/epaper-service.yaml` → `manifests/applications/op1st-gitops/applications/epaper-service.yaml`
- Adjust to mirror `b4mad-meshtastic-gateway`: `metadata.namespace: op1st-gitops`, explicit `destination.server: https://api.nostromo...:6443`, `project: b4mad`
- Drop the kustomization entry under `manifests/applications/`
- Source repo stays on Codeberg (`codeberg.org/goern/epaper-service`)

## Test plan

- [ ] After merge, `oc -n op1st-gitops get application epaper-service` returns Synced/Healthy
- [ ] Top-level `oc -n openshift-gitops get application epaper-service` does NOT exist (pruned by app-of-apps)
- [ ] `oc -n b4mad-epaper-service get all` shows the workloads
- [ ] `curl https://<route>/healthz` returns `{"status":"ok"}`