### PR TITLE
chore(nostromo): rename Application + file to b4mad-epaper-service

### DIFF
--- a/manifests/applications/op1st-gitops/applications/b4mad-epaper-service.yaml
+++ b/manifests/applications/op1st-gitops/applications/b4mad-epaper-service.yaml
@@ -3,7 +3,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: epaper-service
+  name: b4mad-epaper-service
   namespace: op1st-gitops
 spec:
   destination:


### PR DESCRIPTION
## Summary

Match the `b4mad-*` naming convention used by every other end-user service under `op1st-gitops/applications/` (`b4mad-meshtastic-gateway`, `b4mad-keycloak`, `b4mad-racing`, `b4mad-radicle`, `b4mad-renovate`).

- File: `epaper-service.yaml` → `b4mad-epaper-service.yaml`
- Application `metadata.name`: `epaper-service` → `b4mad-epaper-service`
- Destination namespace `b4mad-epaper-service` was already correctly prefixed.

After merge, the old `epaper-service` Application gets pruned by the parent `op1st-gitops` Application (`prune: true`), and the new `b4mad-epaper-service` Application is created in its place. Workloads in the `b4mad-epaper-service` namespace will briefly disappear and come back.

## Test plan

- [ ] `oc -n op1st-gitops get application b4mad-epaper-service` returns Synced/Healthy
- [ ] `oc -n op1st-gitops get application epaper-service` does NOT exist
- [ ] `oc -n b4mad-epaper-service get all` shows the workloads
- [ ] `curl https://<route>/healthz` returns `{"status":"ok"}`