### PR TITLE
fix(nostromo): register b4mad-epaper-service in op1st-gitops kustomization

### DIFF
--- a/manifests/applications/op1st-gitops/kustomization.yaml
+++ b/manifests/applications/op1st-gitops/kustomization.yaml
@@ -19,6 +19,7 @@ resources:
   - projects/
   - repositories/
 
+  - applications/b4mad-epaper-service.yaml
   - applications/b4mad-keycloak.yaml
   - applications/b4mad-meshtastic-gateway.yaml
   - applications/b4mad-racing.yaml


### PR DESCRIPTION
## Summary

Same root cause as PR #77 but one level deeper. The `b4mad-epaper-service.yaml` Application file landed under `manifests/applications/op1st-gitops/applications/` via PR #78 + #79, but was never listed in the parent `manifests/applications/op1st-gitops/kustomization.yaml` resources list — Kustomize uses an explicit list there too, mirroring `b4mad-meshtastic-gateway.yaml`, `b4mad-keycloak.yaml`, etc. Without this entry, the file is silently skipped and `b4mad-epaper-service` Application is never created.

This PR adds the one-line registration.

## Test plan

- [ ] After merge, `oc -n op1st-gitops get application b4mad-epaper-service` returns Synced/Healthy
- [ ] `oc -n b4mad-epaper-service get all` shows the workloads
- [ ] `curl https://epaper.erdgeschoss.b4mad.net/healthz` returns `{"status":"ok"}` (assumes DNS + cert-manager round-trip)