### PR TITLE
fix(nostromo): dedupe node_hwmon_sensor_label join in bridge-host-cpu dashboard

### DIFF
--- a/manifests/applications/b4mad-meshtastic-gateway/perses/bridge-host-cpu-dashboard.yaml
+++ b/manifests/applications/b4mad-meshtastic-gateway/perses/bridge-host-cpu-dashboard.yaml
@@ -198,7 +198,9 @@ data:
                       query: |-
                         node_hwmon_temp_celsius{instance="bridge", chip="platform_coretemp_0"}
                         * on (chip, sensor) group_left(label)
-                        node_hwmon_sensor_label{instance="bridge", chip="platform_coretemp_0"}
+                        max by (chip, sensor, label) (
+                          node_hwmon_sensor_label{instance="bridge", chip="platform_coretemp_0"}
+                        )
                       seriesNameFormat: "{{label}}"
                       datasource: { kind: PrometheusDatasource, name: prometheus }
 


### PR DESCRIPTION
## Summary

Bridge host CPU dashboard's coretemp panel hits PromQL `many-to-many matching not allowed` error when node-exporter pod restarts. Two `node_hwmon_sensor_label` series for the same `{chip, sensor}` on `instance="bridge"` coexist within Prometheus' 5m staleness window (old+new node-exporter pod), so the bare `group_left(label)` join blows up.

Wrap RHS in `max by (chip, sensor, label)` to collapse duplicates back to one row per (chip, sensor, label). Self-heals across rolling restarts and DaemonSet eviction races.

## Test plan

- [ ] After merge + Argo sync, open https://perses.b4mad.emea.operate-first.cloud/projects/nostromo-cluster-health/dashboards/bridge-host-cpu and confirm the per-core temperature panel renders (legend shows "Core 0".."Core 5" / "Package id 0", not the error).
- [ ] Run `count by (chip, sensor, instance) (node_hwmon_sensor_label{instance="bridge"})` during a node-exporter restart — values may briefly hit 2; the panel should keep rendering.