### PR TITLE
fix(nostromo): epaper Perses dashboard readability

### DIFF
--- a/manifests/applications/b4mad-meshtastic-gateway/perses/epaper-service-dashboard.yaml
+++ b/manifests/applications/b4mad-meshtastic-gateway/perses/epaper-service-dashboard.yaml
@@ -31,7 +31,12 @@ data:
     spec:
       display:
         name: "epaper-service — DevOps / SRE"
-      duration: 6h
+        description: |
+          Operational view of goern/epaper-service running in the
+          b4mad-epaper-service namespace on nostromo. Sections cover
+          service status, render pipeline, HTTP, state store, auth and
+          workload. Image source: codeberg.org/goern/epaper-service.
+      duration: 1h
       refreshInterval: 30s
 
       variables:
@@ -55,7 +60,9 @@ data:
         scrape_up:
           kind: Panel
           spec:
-            display: { name: "Scrape up" }
+            display:
+              name: "Scrape up"
+              description: "Prometheus scrape result for the epaper-service Service. Green = at least one pod reachable on /metrics."
             plugin:
               kind: StatChart
               spec:
@@ -77,7 +84,9 @@ data:
         build_info:
           kind: Panel
           spec:
-            display: { name: "Build info (version / scenes)" }
+            display:
+              name: "Build info"
+              description: "Version + scene_count emitted by the running pod. Multiple lines mean a rolling update happened in this window."
             plugin:
               kind: TimeSeriesChart
               spec:
@@ -98,7 +107,9 @@ data:
         uptime:
           kind: Panel
           spec:
-            display: { name: "Process uptime" }
+            display:
+              name: "Process uptime"
+              description: "now() - process_start_time_seconds. Resets on every pod restart."
             plugin:
               kind: StatChart
               spec:
@@ -116,7 +127,9 @@ data:
         current_scene:
           kind: Panel
           spec:
-            display: { name: "Current scene" }
+            display:
+              name: "Current scene"
+              description: "Which scene GET /image returns. Only one line is ever at value 1 at any given instant."
             plugin:
               kind: TimeSeriesChart
               spec:
@@ -138,7 +151,9 @@ data:
         render_rate:
           kind: Panel
           spec:
-            display: { name: "Renders / sec by scene & result" }
+            display:
+              name: "Renders / sec by scene & result"
+              description: "rate(epaper_scene_renders_total[5m]). 'ok' is healthy traffic, 'error' is a render exception."
             plugin:
               kind: TimeSeriesChart
               spec:
@@ -156,7 +171,9 @@ data:
         render_p95:
           kind: Panel
           spec:
-            display: { name: "Render duration p95 by scene" }
+            display:
+              name: "Render duration p95 by scene"
+              description: "95th-percentile time spent rendering a scene to PNG + raw buffer. Cache-hit responses do NOT contribute."
             plugin:
               kind: TimeSeriesChart
               spec:
@@ -175,7 +192,9 @@ data:
         cache_hit_ratio:
           kind: Panel
           spec:
-            display: { name: "Render cache hit ratio (5m)" }
+            display:
+              name: "Render cache hit ratio"
+              description: "5-minute hit ratio of the in-process render cache. 100% under steady state with a single client polling /image; drops on state mutations."
             plugin:
               kind: StatChart
               spec:
@@ -204,12 +223,19 @@ data:
         image_age:
           kind: Panel
           spec:
-            display: { name: "Image staleness by scene (now − last_render)" }
+            display:
+              name: "Image staleness by scene"
+              description: "now() - epaper_last_render_unix_seconds per scene. Sawtooth pattern is normal — ramps up between renders, drops to ~0 on a fresh GET /image."
             plugin:
               kind: TimeSeriesChart
               spec:
-                yAxis: { format: { unit: seconds } }
+                yAxis: { format: { unit: seconds }, min: 0 }
                 legend: { position: bottom, mode: list, values: [last] }
+                thresholds:
+                  defaultColor: "#8b949e"
+                  steps:
+                    - { value: 60, color: "#bf8700" }
+                    - { value: 600, color: "#cf222e" }
             queries:
               - kind: TimeSeriesQuery
                 spec:
@@ -224,11 +250,14 @@ data:
         request_rate_by_status:
           kind: Panel
           spec:
-            display: { name: "HTTP requests / sec by status" }
+            display:
+              name: "HTTP requests / sec by status"
+              description: "rate(epaper_requests_total[1m]) grouped by HTTP status. Stacked area: total = stack height."
             plugin:
               kind: TimeSeriesChart
               spec:
                 legend: { position: bottom, mode: list, values: [last] }
+                visual: { display: line, lineWidth: 1, areaOpacity: 0.5, stack: all }
             queries:
               - kind: TimeSeriesQuery
                 spec:
@@ -242,7 +271,9 @@ data:
         request_latency:
           kind: Panel
           spec:
-            display: { name: "HTTP latency p50 / p95 / p99" }
+            display:
+              name: "HTTP latency p50 / p95 / p99"
+              description: "histogram_quantile over a 5-minute window of epaper_request_duration_seconds. p99 spikes typically correspond to render-cache misses (first request after a state mutation)."
             plugin:
               kind: TimeSeriesChart
               spec:
@@ -277,7 +308,9 @@ data:
         five_xx_ratio:
           kind: Panel
           spec:
-            display: { name: "5xx ratio (5m)" }
+            display:
+              name: "5xx ratio"
+              description: "Fraction of HTTP responses with status 5xx over a 5-minute window. Reads 0% when there is no traffic."
             plugin:
               kind: StatChart
               spec:
@@ -307,7 +340,9 @@ data:
         state_writes:
           kind: Panel
           spec:
-            display: { name: "State writes / sec by result" }
+            display:
+              name: "State writes / sec by result"
+              description: "rate(epaper_state_writes_total[5m]). Each POST /current and POST /scenes/message produces one 'ok' write; PVC unwritable produces 'error'."
             plugin:
               kind: TimeSeriesChart
               spec:
@@ -325,7 +360,9 @@ data:
         last_state_write:
           kind: Panel
           spec:
-            display: { name: "Last state-write age" }
+            display:
+              name: "Last state-write age"
+              description: "now() - epaper_last_state_write_unix_seconds. Resets to ~0 on every successful state write."
             plugin:
               kind: StatChart
               spec:
@@ -343,7 +380,9 @@ data:
         auth_failures:
           kind: Panel
           spec:
-            display: { name: "Auth rejections / sec by reason" }
+            display:
+              name: "Auth rejections / sec by reason"
+              description: "Bearer-auth rejections. 'missing_token' = no Authorization header; 'bad_token' = wrong value. Sustained > 1/s warrants checking access logs."
             plugin:
               kind: TimeSeriesChart
               spec:
@@ -365,7 +404,9 @@ data:
         image_bytes:
           kind: Panel
           spec:
-            display: { name: "Last image size by scene & format" }
+            display:
+              name: "Last image size by scene & format"
+              description: "Most recent image size per (scene, format). 'png' is the over-the-wire encoding (~1-3 KiB); 'raw' is the panel-packed buffer (4 KiB exactly for the V4 panel)."
             plugin:
               kind: TimeSeriesChart
               spec:
@@ -385,7 +426,9 @@ data:
         pod_restarts:
           kind: Panel
           spec:
-            display: { name: "Container restarts (kube-state-metrics)" }
+            display:
+              name: "Container restarts"
+              description: "Cumulative kube_pod_container_status_restarts_total. A horizontal line at zero means a healthy boot. Steps up indicate the kubelet restarted the 'app' container."
             plugin:
               kind: TimeSeriesChart
               spec:
@@ -403,7 +446,9 @@ data:
         memory_rss:
           kind: Panel
           spec:
-            display: { name: "Memory RSS" }
+            display:
+              name: "Memory RSS"
+              description: "process_resident_memory_bytes for the FastAPI/uvicorn process. Limit on the Deployment is 256 Mi."
             plugin:
               kind: TimeSeriesChart
               spec:

--- a/manifests/applications/b4mad-meshtastic-gateway/perses/epaper-service-dashboard.yaml
+++ b/manifests/applications/b4mad-meshtastic-gateway/perses/epaper-service-dashboard.yaml
@@ -71,7 +71,7 @@ data:
                   plugin:
                     kind: PrometheusTimeSeriesQuery
                     spec:
-                      query: 'up{namespace="$namespace",service="epaper-service"}'
+                      query: 'max(up{namespace="$namespace",service="epaper-service"})'
                       datasource: { kind: PrometheusDatasource, name: prometheus }
 
         build_info:
@@ -91,7 +91,7 @@ data:
                   plugin:
                     kind: PrometheusTimeSeriesQuery
                     spec:
-                      query: 'epaper_build_info{namespace="$namespace"}'
+                      query: 'max by (version, scene_count) (epaper_build_info{namespace="$namespace"})'
                       seriesNameFormat: "v{{version}} ({{scene_count}} scenes)"
                       datasource: { kind: PrometheusDatasource, name: prometheus }
 
@@ -110,7 +110,7 @@ data:
                   plugin:
                     kind: PrometheusTimeSeriesQuery
                     spec:
-                      query: 'time() - process_start_time_seconds{namespace="$namespace",service="epaper-service"}'
+                      query: 'time() - max(process_start_time_seconds{namespace="$namespace",service="epaper-service"})'
                       datasource: { kind: PrometheusDatasource, name: prometheus }
 
         current_scene:
@@ -130,7 +130,7 @@ data:
                   plugin:
                     kind: PrometheusTimeSeriesQuery
                     spec:
-                      query: 'epaper_current_scene{namespace="$namespace"}'
+                      query: 'max by (name) (epaper_current_scene{namespace="$namespace"})'
                       seriesNameFormat: "{{name}}"
                       datasource: { kind: PrometheusDatasource, name: prometheus }
 
@@ -193,9 +193,12 @@ data:
                     kind: PrometheusTimeSeriesQuery
                     spec:
                       query: |
-                        sum(rate(epaper_render_cache_total{namespace="$namespace",result="hit"}[5m]))
-                          /
-                        sum(rate(epaper_render_cache_total{namespace="$namespace"}[5m]))
+                        (
+                          sum(rate(epaper_render_cache_total{namespace="$namespace",result="hit"}[5m]))
+                            /
+                          clamp_min(sum(rate(epaper_render_cache_total{namespace="$namespace"}[5m])), 1e-9)
+                        )
+                        or on() vector(0)
                       datasource: { kind: PrometheusDatasource, name: prometheus }
 
         image_age:
@@ -213,7 +216,7 @@ data:
                   plugin:
                     kind: PrometheusTimeSeriesQuery
                     spec:
-                      query: 'time() - epaper_last_render_unix_seconds{namespace="$namespace"}'
+                      query: 'time() - max by (scene) (epaper_last_render_unix_seconds{namespace="$namespace"})'
                       seriesNameFormat: "{{scene}}"
                       datasource: { kind: PrometheusDatasource, name: prometheus }
 
@@ -292,9 +295,12 @@ data:
                     kind: PrometheusTimeSeriesQuery
                     spec:
                       query: |
-                        sum(rate(epaper_requests_total{namespace="$namespace",status=~"5.."}[5m]))
-                          /
-                        clamp_min(sum(rate(epaper_requests_total{namespace="$namespace"}[5m])), 0.0001)
+                        (
+                          sum(rate(epaper_requests_total{namespace="$namespace",status=~"5.."}[5m]))
+                            /
+                          clamp_min(sum(rate(epaper_requests_total{namespace="$namespace"}[5m])), 1e-9)
+                        )
+                        or on() vector(0)
                       datasource: { kind: PrometheusDatasource, name: prometheus }
 
         # ─────────────────────── Row 4: state & auth ────────────────────────
@@ -331,7 +337,7 @@ data:
                   plugin:
                     kind: PrometheusTimeSeriesQuery
                     spec:
-                      query: 'time() - epaper_last_state_write_unix_seconds{namespace="$namespace"}'
+                      query: 'time() - max(epaper_last_state_write_unix_seconds{namespace="$namespace"})'
                       datasource: { kind: PrometheusDatasource, name: prometheus }
 
         auth_failures:
@@ -348,7 +354,10 @@ data:
                   plugin:
                     kind: PrometheusTimeSeriesQuery
                     spec:
-                      query: 'sum by (reason) (rate(epaper_auth_failures_total{namespace="$namespace"}[5m]))'
+                      query: |
+                        sum by (reason) (rate(epaper_auth_failures_total{namespace="$namespace"}[5m]))
+                          or label_replace(vector(0), "reason", "missing_token", "", "")
+                          or label_replace(vector(0), "reason", "bad_token", "", "")
                       seriesNameFormat: "{{reason}}"
                       datasource: { kind: PrometheusDatasource, name: prometheus }
 
@@ -368,7 +377,7 @@ data:
                   plugin:
                     kind: PrometheusTimeSeriesQuery
                     spec:
-                      query: 'epaper_image_bytes{namespace="$namespace"}'
+                      query: 'max by (scene, format) (epaper_image_bytes{namespace="$namespace"})'
                       seriesNameFormat: "{{scene}} / {{format}}"
                       datasource: { kind: PrometheusDatasource, name: prometheus }
 
@@ -387,7 +396,7 @@ data:
                   plugin:
                     kind: PrometheusTimeSeriesQuery
                     spec:
-                      query: 'kube_pod_container_status_restarts_total{namespace="$namespace",container="app"}'
+                      query: 'sum by (pod) (kube_pod_container_status_restarts_total{namespace="$namespace",container="app"})'
                       seriesNameFormat: "{{pod}}"
                       datasource: { kind: PrometheusDatasource, name: prometheus }
 
@@ -406,7 +415,7 @@ data:
                   plugin:
                     kind: PrometheusTimeSeriesQuery
                     spec:
-                      query: 'process_resident_memory_bytes{namespace="$namespace",service="epaper-service"}'
+                      query: 'max(process_resident_memory_bytes{namespace="$namespace",service="epaper-service"})'
                       datasource: { kind: PrometheusDatasource, name: prometheus }
 
       layouts:


### PR DESCRIPTION
## Summary

Tightens up the first version of `epaper-service-sre`. Rough edges visible at first load:

- **Stat panels overlaid multiple series** (one per pod / instance / endpoint that Prometheus exposes for `up`, `process_*`, `epaper_*` etc.). Each stat-panel query is now wrapped in `max(...)` or `sum/max by (relevant_labels)(...)` so a single value reaches the chart.
- **Build info** + **Current scene** collapse to `(version, scene_count)` and `(name)` only — drops pod-replica fan-out.
- **Cache hit ratio** and **5xx ratio** surfaced `NaN%` / "No data" when the denominator was zero. Wrapped with `clamp_min + or on() vector(0)` so they read `0%` when traffic is silent.
- **Auth rejections** showed "No data" even though both reasons are declared on our Counter. Synthesise a zero-vector for each expected `reason` via `label_replace` so the chart renders two flat zero lines until a rejection happens.
- **pod_restarts** and **image_bytes** lose per-instance fan-out via `sum/max by (...)` aggregation.
- **Image age** uses `max by (scene)` so freshness is one number per scene.

Net: cleaner readouts, no NaN%, sensible "no traffic" baselines.

## Test plan

- [ ] Argo `b4mad-meshtastic-gateway` Application stays Synced/Healthy
- [ ] Reload the dashboard — stat panels now show single values, ratio panels show `0%` instead of `NaN%`/`No data`