### PR TITLE
feat(op1st-codeberg-runners): ✨ add ApplicationSet for codeberg.org r…

### DIFF
--- a/manifests/applications/kustomization.yaml
+++ b/manifests/applications/kustomization.yaml
@@ -11,5 +11,6 @@ resources:
   - environment-nostromo.yaml
   # - nostromo-gatekeeper.yaml
   - environment-phobos.yaml
+  - op1st-codeberg-runners.yaml
   - op1st-gitops.yaml
   - op1st-pipelines.yaml

--- a/manifests/applications/op1st-codeberg-runners.yaml
+++ b/manifests/applications/op1st-codeberg-runners.yaml
@@ -1,0 +1,34 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: op1st-codeberg-runners
+  namespace: openshift-gitops
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - list:
+        elements:
+          - scope: goern
+            ownerKind: user
+          - scope: b4mad
+            ownerKind: org
+  template:
+    metadata:
+      name: 'op1st-codeberg-runner-{{.scope}}'
+    spec:
+      project: op1st
+      source:
+        repoURL: https://codeberg.org/b4mad/codeberg-runner-openshift.git
+        targetRevision: main
+        path: 'deploy/overlays/{{.scope}}'
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: op1st-pipelines
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=false
+          - ServerSideApply=true


### PR DESCRIPTION
…unners

Generates one Application per scope (goern user + b4mad org) from codeberg.org/b4mad/codeberg-runner-openshift, deploying rootless forgejo-runners with a podman sidecar into op1st-pipelines.

The runner image, manifests, and design are versioned in the source repo. This commit only wires the ApplicationSet into the cluster's ArgoCD app-of-apps.