### PR TITLE
fix(op1st): permit ApplicationSet in op1st AppProject whitelist

### DIFF
--- a/manifests/applications/openshift-gitops/projects/op1st.yaml
+++ b/manifests/applications/openshift-gitops/projects/op1st.yaml
@@ -97,6 +97,8 @@ spec:
     - group: argoproj.io
       kind: Application
     - group: argoproj.io
+      kind: ApplicationSet
+    - group: argoproj.io
       kind: CronWorkflow
     - group: argoproj.io
       kind: Workflow


### PR DESCRIPTION
## Summary

Fixes #84 follow-up: the merged ApplicationSet (\`op1st-codeberg-runners\`) cannot sync because the \`op1st\` AppProject permits \`argoproj.io/Application\` but not \`argoproj.io/ApplicationSet\`.

ArgoCD reports:
\`\`\`
resource argoproj.io:ApplicationSet is not permitted in project op1st
\`\`\`

This adds \`ApplicationSet\` next to \`Application\` in \`namespaceResourceWhitelist\`.

## Test plan
- [ ] After merge, the parent \`app-of-apps\` Application syncs successfully on nostromo
- [ ] \`oc -n openshift-gitops get applicationsets\` shows \`op1st-codeberg-runners\`
- [ ] Two child Applications generated: \`op1st-codeberg-runner-goern\`, \`op1st-codeberg-runner-b4mad\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)