### PR TITLE
fix(op1st): add codeberg runner repo to op1st sourceRepos

### DIFF
--- a/manifests/applications/openshift-gitops/projects/op1st.yaml
+++ b/manifests/applications/openshift-gitops/projects/op1st.yaml
@@ -21,6 +21,7 @@ spec:
       server: https://kubernetes.default.svc
   sourceRepos:
     - https://github.com/b4mad/op1st-emea-b4mad.git
+    - https://codeberg.org/b4mad/codeberg-runner-openshift.git
   roles:
     - name: project-admin
       description: Read/Write access to this project only


### PR DESCRIPTION
Follow-up to PRs #84 and #85. The op1st-codeberg-runners ApplicationSet generates child Applications whose source is codeberg.org/b4mad/codeberg-runner-openshift, but the op1st AppProject only permitted the github.com upstream repo, so children fail to sync with: application repo https://codeberg.org/b4mad/codeberg-runner-openshift.git is not permitted in project 'op1st'. This adds the codeberg URL to sourceRepos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)