### PR TITLE
fix: disable argocd-grpc Ingress on op1st-gitops

### DIFF
--- a/manifests/applications/op1st-gitops/argocd.yaml
+++ b/manifests/applications/op1st-gitops/argocd.yaml
@@ -11,7 +11,7 @@ spec:
     host: argocd.b4mad.emea.operate-first.cloud
     grpc:
       ingress:
-        enabled: true
+        enabled: false
     ingress:
       enabled: false
     insecure: true


### PR DESCRIPTION
## Summary

- Flip `spec.server.grpc.ingress.enabled` from `true` to `false` in the op1st-gitops ArgoCD CR.
- Stops the argocd-operator from emitting a broken Ingress (`argocd-grpc`) stuck without an ADDRESS since creation.

## Why

The argocd-operator's `grpc.ingress` knob targets nginx-ingress-controller environments. On OpenShift it emits an Ingress with:

- bare host `argocd-grpc` (not an FQDN)
- no `ingressClassName`

`openshift-default` cannot route either, so the resource has been inert for years.

ArgoCD CLI on OpenShift talks gRPC-web over the existing edge-terminated Route at `argocd.b4mad.emea.operate-first.cloud` — no separate gRPC endpoint is required. Native gRPC over edge would also break framing; if it were ever needed, the right shape is a passthrough Route, not an Ingress.

After merge, the operator garbage-collects the orphan Ingress.

## Test plan

- [ ] After merge + Application sync, `oc -n op1st-gitops get ingress argocd-grpc` returns `NotFound`.
- [ ] `argocd login argocd.b4mad.emea.operate-first.cloud --grpc-web` succeeds.
- [ ] `argocd app list --grpc-web --server argocd.b4mad.emea.operate-first.cloud` returns the namespace's apps.
- [ ] Web UI at https://argocd.b4mad.emea.operate-first.cloud still loads.

Tracked: Systems-j4b