### PR TITLE
feat: declare hausmeister Argo Application in Git

### DIFF
--- a/manifests/applications/op1st-gitops/applications/hausmeister.yaml
+++ b/manifests/applications/op1st-gitops/applications/hausmeister.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: hausmeister
+  namespace: op1st-gitops
+spec:
+  destination:
+    namespace: b4mad-hausmeister
+    server: https://api.nostromo.erdgeschoss.b4mad.emea.operate-first.cloud:6443
+  project: b4mad
+  source:
+    path: manifests/environments/nostromo
+    repoURL: https://codeberg.org/goern/hausmeister/
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/manifests/applications/op1st-gitops/kustomization.yaml
+++ b/manifests/applications/op1st-gitops/kustomization.yaml
@@ -27,6 +27,7 @@ resources:
   - applications/b4mad-racing.yaml
   - applications/b4mad-radicle.yaml
   - applications/b4mad-renovate.yaml
+  - applications/hausmeister.yaml
   # - applications/op1st-popeye.yaml
   - https://codeberg.org/feeldata/manifests/raw/branch/main/applications/dev.yaml
   - https://codeberg.org/feeldata/manifests/raw/branch/main/applications/prod.yaml


### PR DESCRIPTION
## Why

The `op1st-gitops/hausmeister` Argo Application was applied manually to the cluster — no `argocd.argoproj.io/tracking-id`, not referenced by any app-of-apps kustomization, and live edits did not self-heal. The path was also wrong (`manifests/environments/production` did not exist; real overlay is `manifests/environments/nostromo`), so Argo had been emitting `ComparisonError` and never compared state since the cluster came up.

Path was patched live (`spec.source.path` -> `manifests/environments/nostromo`), Argo synced and adopted the existing live resources via tracking-id stamping. This PR moves the Application into Git so future drift is caught.

## What

- Add `manifests/applications/op1st-gitops/applications/hausmeister.yaml` matching the pattern of `b4mad-keycloak.yaml`.
- Include it from `manifests/applications/op1st-gitops/kustomization.yaml`.

`kustomize build manifests/applications/op1st-gitops/` succeeds locally and emits the new Application object.

## Risk

Low. The Application already exists on the cluster with an equivalent spec (live `targetRevision` is `HEAD`, this PR sets `main` — semantically identical). After merge, openshift-gitops will adopt the Application via server-side apply; no workload restart expected.

## Tracking

Refs: Systems-e4r (parent: Systems-4h5).