### PR TITLE
chore: bump b4mad-renovate image 42.13 -> 43.168

### DIFF
--- a/manifests/applications/b4mad-renovate/kustomization.yaml
+++ b/manifests/applications/b4mad-renovate/kustomization.yaml
@@ -18,4 +18,4 @@ resources:
 
 images:
   - name: renovate
-    newName: docker.io/renovate/renovate:42.13
+    newName: docker.io/renovate/renovate:43.168


### PR DESCRIPTION
## Why

`docker.io/renovate/renovate:42.13` was published 2025-11-17 (~6 months stale).

## v43 breaking-change audit vs this config

| Change | Affects b4mad-renovate? |
|---|---|
| Gradle wrapper allowlist (`allowedUnsafeExecutions`) | No — no Gradle repos in renovate's repository list |
| `postUpgradeTasks` no-shell default | No — config uses `allowedCommands`, not `postUpgradeTasks` |
| `binarySource=docker` deprecated | No — config sets `binarySource: "install"` |
| ESM packaging | No — not consumed as a library |
| `config:best-practices` weekly lockfile | Cosmetic on downstream renovated repos that extend it; not a break here |

## Tracking

Refs: Systems-f06.