### PR TITLE
chore: b4mad-keycloak PDBs minAvailable 1 -> 0

### DIFF
--- a/manifests/applications/b4mad-keycloak/pod-disruption-budget.yaml
+++ b/manifests/applications/b4mad-keycloak/pod-disruption-budget.yaml
@@ -4,7 +4,7 @@ kind: PodDisruptionBudget
 metadata:
   name: keycloak
 spec:
-  minAvailable: 1
+  minAvailable: 0
   selector:
     matchLabels:
       app.kubernetes.io/instance: b4mad-erdgeschoss
@@ -15,7 +15,7 @@ kind: PodDisruptionBudget
 metadata:
   name: pooler
 spec:
-  minAvailable: 1
+  minAvailable: 0
   selector:
     matchLabels:
       cnpg.io/poolerName: pooler-postgresql


### PR DESCRIPTION
## Why

Two PDBs in `manifests/applications/b4mad-keycloak/pod-disruption-budget.yaml`:

| PDB | Workload | Replicas |
|---|---|---|
| `keycloak` | StatefulSet `b4mad-erdgeschoss` | 1 |
| `pooler` | Deployment `pooler-postgresql` | 1 |

Both run on nostromo (single-node OpenShift, node `bridge`). `minAvailable: 1` guarantees node drains/upgrades hang because the only pod cannot be moved off the only node. Prometheus has been firing `PodDisruptionBudgetAtLimit` for both.

## What

Set `spec.minAvailable: 0` on both. Drain proceeds; pods restart during the reboot window.

## Alternatives considered

- **Delete the PDBs** — equivalent on SNO, but keeping the objects documents the intent in-tree.
- **Scale to 2 replicas** — fake HA on SNO (both pods land on `bridge`), doesn't help drain.

The CNPG-managed `postgresql` and `postgresql-primary` PDBs are intentionally unchanged: they belong to a 3-instance cluster and the operator manages them.

## Tracking

Refs: Systems-kmt, Systems-6lz (parent Systems-fpd "nostromo: review single-replica PDBs blocking drains").