### PR TITLE
chore: drop CNPG -primary PDB-at-limit alert noise

### DIFF
--- a/manifests/environments/nostromo/alerting/drop-cnpg-primary-pdb-at-limit.yaml
+++ b/manifests/environments/nostromo/alerting/drop-cnpg-primary-pdb-at-limit.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.openshift.io/v1
+kind: AlertRelabelConfig
+metadata:
+  name: drop-cnpg-primary-pdb-at-limit
+  namespace: openshift-monitoring
+spec:
+  configs:
+    # CloudNativePG ships two PDBs per cluster: one for the cluster (lets
+    # replicas drain) and one pinning the primary (always 0 disruptions
+    # allowed by design — switchover promotes a replica before drain).
+    # PodDisruptionBudgetAtLimit firing on the `*-primary` PDB is therefore
+    # a permanent false positive. Drop it before it reaches Alertmanager.
+    - sourceLabels:
+        - alertname
+        - poddisruptionbudget
+      separator: ;
+      regex: PodDisruptionBudgetAtLimit;.*-primary
+      action: Drop

--- a/manifests/environments/nostromo/alerting/kustomization.yaml
+++ b/manifests/environments/nostromo/alerting/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - sno-bridge-disk.yaml
   - sno-bridge-thermal.yaml
+  - drop-cnpg-primary-pdb-at-limit.yaml


### PR DESCRIPTION
## Why

CloudNativePG ships two PDBs per cluster:

- `<cluster>` — selects all instances, allows replicas to drain.
- `<cluster>-primary` — pins the primary, **always 0 disruptions allowed by design**. This is the mechanism that forces a switchover before voluntary disruption.

`PodDisruptionBudgetAtLimit` firing on `*-primary` PDBs is therefore a permanent false positive — the alert correctly reports the state, but the state is intentional.

Affected today on nostromo:

| Namespace | PDB |
|---|---|
| `b4mad-keycloak` | `postgresql-primary` |
| `b4mad-matrix` | `prod-primary` |
| `feeldata-prod` | `prod-primary` |
| `openshift-pipelines` | `postgresql-primary` |

## What

Add an `AlertRelabelConfig` (`monitoring.openshift.io/v1`) in `openshift-monitoring` that drops the alert when both labels match:

- `alertname=PodDisruptionBudgetAtLimit`
- `poddisruptionbudget=~".*-primary"`

`AlertRelabelConfig` is the OpenShift-native, GitOps-friendly drop mechanism — it relabels alerts in the platform Alertmanager pipeline before they fan out to receivers.

## Risk

Low. Only the alert is dropped; the PDB itself still functions. A non-CNPG PDB named `*-primary` would also be silenced — none currently exist, and the regex can be tightened later if that changes.

Server-side dry-run apply succeeded against the cluster.

## Tracking

Refs: Systems-bfd.