### PR TITLE
fix: grant Argo controller RBAC for monitoring.openshift.io

### DIFF
--- a/manifests/environments/nostromo/alerting/drop-cnpg-primary-pdb-at-limit.yaml
+++ b/manifests/environments/nostromo/alerting/drop-cnpg-primary-pdb-at-limit.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.openshift.io/v1
+kind: AlertRelabelConfig
+metadata:
+  name: drop-cnpg-primary-pdb-at-limit
+  namespace: openshift-monitoring
+spec:
+  configs:
+    # CloudNativePG ships two PDBs per cluster: one for the cluster (lets
+    # replicas drain) and one pinning the primary (always 0 disruptions
+    # allowed by design — switchover promotes a replica before drain).
+    # PodDisruptionBudgetAtLimit firing on the `*-primary` PDB is therefore
+    # a permanent false positive. Drop it before it reaches Alertmanager.
+    - sourceLabels:
+        - alertname
+        - poddisruptionbudget
+      separator: ;
+      regex: PodDisruptionBudgetAtLimit;.*-primary
+      action: Drop

--- a/manifests/environments/nostromo/alerting/kustomization.yaml
+++ b/manifests/environments/nostromo/alerting/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - sno-bridge-disk.yaml
   - sno-bridge-thermal.yaml
+  - drop-cnpg-primary-pdb-at-limit.yaml

--- a/manifests/environments/nostromo/openshift-gitops/kustomization.yaml
+++ b/manifests/environments/nostromo/openshift-gitops/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - rbac/integreatly-grafana.yaml
   - rbac/openshift-performanceprofiles.yaml
   - rbac/openshift-gitops-integration.yaml
+  - rbac/openshift-monitoring.yaml
   - secrets/op1st-argocd-b4mad-installation.yaml
 
   - gitops-application.yaml

--- a/manifests/environments/nostromo/openshift-gitops/rbac/openshift-monitoring.yaml
+++ b/manifests/environments/nostromo/openshift-gitops/rbac/openshift-monitoring.yaml
@@ -1,0 +1,32 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openshift-monitoring-admin
+rules:
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - monitoring.openshift.io
+    resources:
+      - alertrelabelconfigs
+      - alertingrules
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openshift-gitops-argocd-openshift-monitoring-manager
+subjects:
+  - kind: ServiceAccount
+    name: openshift-gitops-argocd-application-controller
+    namespace: openshift-gitops
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: openshift-monitoring-admin


### PR DESCRIPTION
## Why

PR #91 added an `AlertRelabelConfig` in `openshift-monitoring`. After merge, Argo's `environment-nostromo` Application got stuck applying it:

```
alertrelabelconfigs.monitoring.openshift.io "drop-cnpg-primary-pdb-at-limit"
is forbidden: User "system:serviceaccount:openshift-gitops:openshift-gitops-
argocd-application-controller" cannot patch resource "alertrelabelconfigs"
in API group "monitoring.openshift.io" in the namespace "openshift-monitoring"
```

The OpenShift GitOps Operator-managed ClusterRole `openshift-gitops-openshift-gitops-argocd-application-controller` grants the Argo controller SA cluster-wide `get/list/watch`, plus full mutation on a hand-picked set of apiGroups (`operators.coreos.com`, `operator.openshift.io`, `config.openshift.io`, `machine.openshift.io`, `machineconfiguration.openshift.io`, etc.). `monitoring.openshift.io` is not on that list.

## What

Add a `ClusterRole` + `ClusterRoleBinding` granting the controller SA mutate verbs on `alertrelabelconfigs` and `alertingrules` in `monitoring.openshift.io`, mirroring the existing pattern in `rbac/openshift-performanceprofiles.yaml` and `rbac/integreatly-grafana.yaml`.

Server-side dry-run apply succeeded.

## Tracking

Refs: Systems-bfd. Follow-up to #91.