### PR TITLE
chore: argocd: raise reconcile timeout to 10m, expand resource exclusions

### DIFF
--- a/manifests/applications/op1st-gitops/argocd.yaml
+++ b/manifests/applications/op1st-gitops/argocd.yaml
@@ -96,6 +96,8 @@ spec:
       requests:
         cpu: 50m
         memory: 128Mi
+  extraConfig:
+    timeout.reconciliation: 600s
   resourceExclusions: |
     - apiGroups:
       - tekton.dev
@@ -104,6 +106,31 @@ spec:
       kinds:
       - TaskRun
       - PipelineRun
+    - apiGroups:
+      - ""
+      clusters:
+      - '*'
+      kinds:
+      - Event
+      - Endpoints
+    - apiGroups:
+      - discovery.k8s.io
+      clusters:
+      - '*'
+      kinds:
+      - EndpointSlice
+    - apiGroups:
+      - coordination.k8s.io
+      clusters:
+      - '*'
+      kinds:
+      - Lease
+    - apiGroups:
+      - events.k8s.io
+      clusters:
+      - '*'
+      kinds:
+      - Event
   ha:
     enabled: false
   tls:

--- a/manifests/environments/nostromo/openshift-gitops/kustomization.yaml
+++ b/manifests/environments/nostromo/openshift-gitops/kustomization.yaml
@@ -23,6 +23,41 @@ patches:
         name: openshift-gitops
         namespace: openshift-gitops
       spec:
+        extraConfig:
+          timeout.reconciliation: 600s
+        resourceExclusions: |
+          - apiGroups:
+            - tekton.dev
+            clusters:
+            - '*'
+            kinds:
+            - TaskRun
+            - PipelineRun
+          - apiGroups:
+            - ""
+            clusters:
+            - '*'
+            kinds:
+            - Event
+            - Endpoints
+          - apiGroups:
+            - discovery.k8s.io
+            clusters:
+            - '*'
+            kinds:
+            - EndpointSlice
+          - apiGroups:
+            - coordination.k8s.io
+            clusters:
+            - '*'
+            kinds:
+            - Lease
+          - apiGroups:
+            - events.k8s.io
+            clusters:
+            - '*'
+            kinds:
+            - Event
         notifications:
           enabled: true
           resources:


### PR DESCRIPTION
## Summary

- `timeout.reconciliation: 600s` (operator default 120s) — cuts periodic refresh rate 3-5× for stable apps. Webhook-driven syncs unaffected.
- Extend `resourceExclusions` with cluster-wide noisy kinds: `Event` (core + events.k8s.io), `Endpoints`, `EndpointSlice`, `Lease`. Removes them from controller watch cache + diff scope. Tekton exclusions preserved.
- Applied symmetrically to both ArgoCD instances:
  - `manifests/applications/op1st-gitops/argocd.yaml` (op1st-gitops)
  - `manifests/environments/nostromo/openshift-gitops/kustomization.yaml` (openshift-gitops, via strategic-merge patch)

## Context

Both `application-controller` pods were burning sustained CPU (~300m and ~250m respectively) on a cluster with 23 Argo Applications. Three additional levers identified:

- **P0** — fix flapping `selfHeal` apps (`environment-nostromo`, `environment-phobos`, `b4mad-racing`) — tracked separately in beads.
- **P2/P3** — this PR.
- **P1** — consolidating both ArgoCD instances into one — explicitly deferred; ADR pending.

## Test plan

- [ ] After merge, ArgoCD self-syncs both `openshift-gitops` and `op1st-gitops` apps.
- [ ] Verify `oc get cm -n openshift-gitops argocd-cm -o jsonpath='{.data.timeout\.reconciliation}'` returns `600s`.
- [ ] Verify same on `op1st-gitops`.
- [ ] Verify `oc get argocd -n openshift-gitops openshift-gitops -o jsonpath='{.spec.resourceExclusions}'` includes `EndpointSlice` and `Lease`.
- [ ] Wait 30 min, then `oc adm top pods -n openshift-gitops` and `-n op1st-gitops` — expect controller CPU drop ≥30%.
- [ ] Confirm no apps stuck in stale state (`oc get applications -A -o wide`).