### PR TITLE
fix: argocd: grant controller SA RBAC for monitoring.openshift.io alerting CRs

### DIFF
--- a/manifests/environments/nostromo/openshift-gitops/rbac/openshift-gitops-integration.yaml
+++ b/manifests/environments/nostromo/openshift-gitops/rbac/openshift-gitops-integration.yaml
@@ -110,6 +110,19 @@ rules:
       - create
       - patch
   - apiGroups:
+      - monitoring.openshift.io
+    resources:
+      - alertrelabelconfigs
+      - alertingrules
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
       - nmstate.io
     resources:
       - nodenetworkconfigurationpolicies


### PR DESCRIPTION
## Summary

Add `monitoring.openshift.io/{alertrelabelconfigs,alertingrules}` write rules to `openshift-gitops-environment-manager-role`. The role is already bound to `system:serviceaccount:openshift-gitops:openshift-gitops-argocd-application-controller` via the existing `openshift-gitops-environment-manager` ClusterRoleBinding — no new binding needed.

## Why

Since upstream commit 96c08b3 introduced `manifests/environments/nostromo/alerting/drop-cnpg-primary-pdb-at-limit.yaml`, the `environment-nostromo` Argo Application has been stuck `OutOfSync` with `selfHeal: true` retrying every 2 minutes. Each retry forces a 141-resource diff + apply, dominating openshift-gitops application-controller CPU (sustained ~300m).

The controller SA had `monitoring.coreos.com` perms (Prometheus rules / ServiceMonitors / PodMonitors) but not `monitoring.openshift.io` — these are different API groups. AlertRelabelConfig and AlertingRule are OpenShift-native CRs introduced for cluster-monitoring user customization; they live in `monitoring.openshift.io/v1`.

Closes the perpetual retry loop. Expected CPU drop on the controller: ~100-150m sustained.

## Verification

- [x] `kustomize build manifests/environments/nostromo/openshift-gitops/` includes the new rule
- [ ] After merge + sync: `oc auth can-i patch alertrelabelconfigs.monitoring.openshift.io -n openshift-monitoring --as=system:serviceaccount:openshift-gitops:openshift-gitops-argocd-application-controller` returns `yes`
- [ ] `oc get application -n openshift-gitops environment-nostromo -o jsonpath='{.status.sync.status}'` returns `Synced`
- [ ] `oc adm top pods -n openshift-gitops openshift-gitops-application-controller-0` drops materially over 10–30 min

## Scope

Tight rule: only the two kinds in `monitoring.openshift.io/v1` (`alertrelabelconfigs`, `alertingrules`). All standard CRUD verbs (`create, delete, get, list, patch, update, watch`) so future ServerSideApply, retries, and pruning all work without further RBAC churn.

Closes beads issue Systems-pkm.