### PR TITLE
fix: argocd: canonicalize controller cpu limit (1000m -> '1')

### DIFF
--- a/manifests/environments/nostromo/openshift-gitops/kustomization.yaml
+++ b/manifests/environments/nostromo/openshift-gitops/kustomization.yaml
@@ -105,7 +105,7 @@ patches:
         controller:
           resources:
             limits:
-              cpu: 1000m
+              cpu: "1"
               memory: 4Gi
             requests:
               cpu: 250m


### PR DESCRIPTION
## Summary

`manifests/environments/nostromo/openshift-gitops/kustomization.yaml`: change controller `cpu: 1000m` to `cpu: \"1\"`.

## Why

Kubernetes' `resource.Quantity` canonicalizes `1000m` → `1` on round-trip through the API server. ArgoCD then diffs the live `\"1\"` against the desired `1000m` and reports the ArgoCD CR as **OutOfSync** — chronic, never resolves, every reconcile re-runs the diff.

The two values are semantically identical; this is a string-representation fight, not a real drift. Aligning the manifest to the canonical form silences it.

The quoted `\"1\"` form is intentional: bare `1` is parsed by YAML as an int and would fail CR validation (Quantity expects a string).

## Test plan

- [x] `kustomize build` emits `cpu: \"1\"`
- [ ] After merge + sync: `oc get application -n openshift-gitops environment-nostromo -o jsonpath='{.status.sync.status}'` returns `Synced`, and `ArgoCD/openshift-gitops` no longer in the resource diff.