### PR TITLE
chore: release CNPG cluster + S3 creds to b4mad-matrix repo

### DIFF
--- a/manifests/applications/b4mad-matrix/dendrite/kustomization.yaml
+++ b/manifests/applications/b4mad-matrix/dendrite/kustomization.yaml
@@ -12,8 +12,11 @@ resources:
   - namespace.yaml
   - serviceaccount.yaml
 
-  - aws-creds.yaml
-  - postgresql.yaml
+  # postgresql.yaml + aws-creds.yaml released to codeberg.org/b4mad/b4mad-matrix
+  # (Cluster prod, Pooler prod-pooler, ScheduledBackup prod-daily, and the S3
+  # backup creds Secret are now owned by the b4mad-matrix Application). The
+  # files remain on disk for git history and are deleted in a follow-up PR
+  # once Phase 9 of the ESS migration retires the Dendrite tree wholesale.
 
   - deployment.yaml
   - ingress.yaml


### PR DESCRIPTION
## Summary

Unhooks `postgresql.yaml` (Cluster `prod` + Pooler `prod-pooler` + ScheduledBackup `prod-daily`) and `aws-creds.yaml` from the `b4mad-matrix-dendrite` Kustomization. These four stateful resources are now owned by a new ArgoCD Application sourced from [codeberg.org/b4mad/b4mad-matrix](https://codeberg.org/b4mad/b4mad-matrix) as part of the ESS (Element Server Suite) migration — Phase 2 of [openspec change `replace-b4mad-matrix-with-ess`](https://codeberg.org/b4mad/b4mad-matrix/src/branch/main/openspec/changes/replace-b4mad-matrix-with-ess/proposal.md).

The files remain on disk for git history; deletion happens in a separate follow-up PR after Phase 9 retires the Dendrite tree wholesale.

## Why now

The new `b4mad-matrix` Application carries the canonical Cluster manifest at `cnpg/cluster.yaml`. Without this PR, two ArgoCD Applications would both claim ownership of the live Cluster CR and oscillate the `argocd.argoproj.io/tracking-id` annotation on every sync. The handoff procedure (steps below) makes the old App stop trying first, then the new App adopts cleanly.

## Pre-merge safety (already applied to live cluster)

- [x] `Cluster prod`, `Pooler prod-pooler`, `ScheduledBackup prod-daily`, and `Secret aws-creds` annotated with `argocd.argoproj.io/sync-options: Prune=false`. The existing Application cannot delete them when it next syncs.
- [x] `b4mad-matrix-dendrite` Application's `spec.syncPolicy.automated` removed; sync is now manual until Phase 9 decommission.
- [x] `Cluster.spec.storage.resourcePolicy: retain` in the new b4mad-matrix manifest. PVCs survive even an explicit Cluster CR delete.
- [x] Recent `prod-daily-20260508043000` backup completed.
- [x] VolumeSnapshot `dendrite-media-pre-cutover-2026-05-08` taken (1Gi, ready).

## What this PR does NOT change

- The Cluster, Pooler, and ScheduledBackup resources continue to run unmodified — same name, same namespace, same spec. Postgres data is untouched.
- The `b4mad-matrix-dendrite` Application keeps managing the Dendrite Deployment + Ingress + Service + PVCs. Those are decommissioned in Phase 9.
- Dendrite users are unaffected; this is invisible to them.

## Test plan

- [ ] Reviewer confirms `Prune=false` annotation on all 4 live CRs:
  ```
  oc -n b4mad-matrix get cluster/prod pooler/prod-pooler scheduledbackup/prod-daily secret/aws-creds \
    -o jsonpath='{range .items[*]}{.metadata.name}{": "}{.metadata.annotations.argocd\.argoproj\.io/sync-options}{"\n"}{end}'
  ```
- [ ] Reviewer confirms `b4mad-matrix-dendrite` Application has no `spec.syncPolicy.automated`.
- [ ] After merge, sync `b4mad-matrix-dendrite` once. Expected: ArgoCD reports the 4 resources as `OutOfSync` ("extra" — not in desired state) but does NOT delete them. Cluster `phase: Cluster in healthy state` unchanged.
- [ ] After merge + (1) above, the operator follows [`docs/runbooks/cnpg-cluster-ownership-handoff.md` Steps 4-6](https://codeberg.org/b4mad/b4mad-matrix/src/branch/main/docs/runbooks/cnpg-cluster-ownership-handoff.md) on the b4mad-matrix repo to register the new Application and flip the `tracking-id` annotation on each CR.

## Rollback

```bash
# Revert this PR (re-add the two files to the kustomization)
git revert <merge-commit-sha>
git push

# Re-enable auto-sync on the existing App
argocd app set b4mad-matrix-dendrite --sync-policy automated --auto-prune --self-heal
```

The `Prune=false` annotation on the CRs and the `Cluster.spec.storage.resourcePolicy: retain` in the new manifest mean Postgres data is safe even if both rollback and re-attempt happen.

## Related

- ESS proposal: <https://codeberg.org/b4mad/b4mad-matrix/src/branch/main/openspec/changes/replace-b4mad-matrix-with-ess/proposal.md>
- Handoff runbook: <https://codeberg.org/b4mad/b4mad-matrix/src/branch/main/docs/runbooks/cnpg-cluster-ownership-handoff.md>
- Cutover runbook: <https://codeberg.org/b4mad/b4mad-matrix/src/branch/main/docs/runbooks/cutover-day.md>