### PR TITLE
feat: register b4mad-matrix Application (ESS migration)

### DIFF
--- a/manifests/applications/op1st-gitops/applications/b4mad-matrix.yaml
+++ b/manifests/applications/op1st-gitops/applications/b4mad-matrix.yaml
@@ -1,0 +1,53 @@
+# ArgoCD Application: b4mad-matrix (ESS — Element Server Suite).
+#
+# Replaces b4mad-matrix-dendrite. The workload manifests live in
+# https://codeberg.org/b4mad/b4mad-matrix; the Helm chart comes from the
+# upstream OCI registry.
+#
+# Multi-source layout:
+#   1. Chart from OCI (matrix-stack)
+#   2. Codeberg repo as $values alias (for `valueFiles: $values/values.yaml`)
+#   3. Codeberg repo as a kustomize deploy source for the bootstrap
+#      manifests (namespace, CNPG Cluster + Pooler + ScheduledBackup,
+#      Database CRs, SealedSecrets). This is what flips ownership of the
+#      existing Cluster `prod` CR from b4mad-matrix-dendrite to this
+#      Application via the tracking-id annotation.
+#
+# Auto-sync deliberately UNSET until the Phase 7 cutover is proven; see
+# docs/runbooks/cutover-day.md in the b4mad-matrix repo. After Phase 10
+# lockdown set:
+#   syncPolicy.automated.prune: false
+#   syncPolicy.automated.selfHeal: false
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: b4mad-matrix
+  namespace: op1st-gitops
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: b4mad
+  destination:
+    name: nostromo
+    namespace: b4mad-matrix
+  sources:
+    - repoURL: ghcr.io/element-hq/ess-helm
+      chart: matrix-stack
+      targetRevision: 26.5.0
+      helm:
+        releaseName: prod
+        valueFiles:
+          - $values/values.yaml
+    - repoURL: https://codeberg.org/b4mad/b4mad-matrix.git
+      targetRevision: HEAD
+      ref: values
+    - repoURL: https://codeberg.org/b4mad/b4mad-matrix.git
+      targetRevision: HEAD
+      path: .
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=false
+      - ServerSideApply=true
+      - RespectIgnoreDifferences=true

--- a/manifests/applications/op1st-gitops/kustomization.yaml
+++ b/manifests/applications/op1st-gitops/kustomization.yaml
@@ -21,6 +21,7 @@ resources:
 
   - applications/b4mad-epaper-service.yaml
   - applications/b4mad-epaper-service-tekton-secrets.yaml
+  - applications/b4mad-matrix.yaml
   - applications/b4mad-matrix-hookshot.yaml
   - applications/b4mad-keycloak.yaml
   - applications/b4mad-meshtastic-gateway.yaml


### PR DESCRIPTION
## Summary

Brings the new `b4mad-matrix` ArgoCD Application under op1st-gitops management. Companion to merged PR #97 which released the CNPG cluster CRs from the old `b4mad-matrix-dendrite` Application. After this PR merges, the parent `op1st-gitops` Application picks up the new `b4mad-matrix` Application; the hand-applied copy currently in the cluster gets adopted via `tracking-id` flip.

Part of openspec change [`replace-b4mad-matrix-with-ess`](https://codeberg.org/b4mad/b4mad-matrix/src/branch/main/openspec/changes/replace-b4mad-matrix-with-ess/proposal.md).

## What lands

`manifests/applications/op1st-gitops/applications/b4mad-matrix.yaml` — multi-source ArgoCD Application:

1. **Helm chart from OCI**: `ghcr.io/element-hq/ess-helm/matrix-stack` pinned to `26.5.0`.
2. **codeberg.org/b4mad/b4mad-matrix as `$values` alias** so source (1) can do `valueFiles: $values/values.yaml`.
3. **codeberg.org/b4mad/b4mad-matrix as a kustomize deploy source (`path: .`)** for the bootstrap layer: namespace label-adoption, CNPG `Cluster prod` + `Pooler` + `ScheduledBackup`, Database CRs for `synapse` + `mas`, and all SealedSecrets the chart consumes.

Source 3 is what completes ownership transfer of `Cluster prod` / `Pooler prod-pooler` / `ScheduledBackup prod-daily` from the old App to this one. PR #97 unhooked them from the dendrite Kustomization (so they showed up as `OutOfSync`/extras there); this PR provides the new home for them.

## Sync policy

`syncPolicy.automated` deliberately UNSET. Sync is manual until the Phase 7 cutover proves the deployment. After Phase 10 lockdown, the runbook (b4mad-matrix repo `docs/runbooks/cutover-day.md` post-cutover section) flips it to `prune: false, selfHeal: false`.

`syncOptions`:
- `CreateNamespace=false` — the `b4mad-matrix` ns already exists.
- `ServerSideApply=true` — required by the chart's Helm hooks and CRD-shaped resources.
- `RespectIgnoreDifferences=true` — for future ignoreDifferences rules without losing them on resync.

## Test plan

- [ ] Reviewer confirms `manifests/applications/op1st-gitops/applications/b4mad-matrix.yaml` parses with `kustomize build manifests/applications/op1st-gitops/ | grep -A20 'name: b4mad-matrix$'`.
- [ ] After merge, the parent Application syncs and `oc -n op1st-gitops get application b4mad-matrix -o jsonpath='{.metadata.annotations.argocd\\.argoproj\\.io/tracking-id}'` shows `op1st-gitops:argoproj.io/Application:op1st-gitops/b4mad-matrix` (no longer `<none>`).
- [ ] Sync the b4mad-matrix App once: `argocd app sync b4mad-matrix`. Expected: `Cluster prod` / `Pooler prod-pooler` / `ScheduledBackup prod-daily` / `Secret aws-creds` reach `Synced` (their `tracking-id` flips from `b4mad-matrix-dendrite:…` to `b4mad-matrix:…`); chart-rendered resources (Synapse, MAS, Element Admin, Hookshot) reach `Healthy: Missing` until the cutover triggers them.
- [ ] CNPG `Cluster prod` `phase: Cluster in healthy state` unchanged through the sync.

## Rollback

```bash
git revert <merge-commit-sha>
git push
# The hand-applied b4mad-matrix Application becomes unmanaged again
# (tracking-id reverts to <none>). It still exists in the cluster but
# is no longer under GitOps management. Delete with:
oc -n op1st-gitops delete application b4mad-matrix --cascade=foreground=false
```

The CNPG resources stay alive throughout (Prune=false annotations + `resourcePolicy: retain`).

## Related

- Companion: #97 (release CNPG cluster + S3 creds to b4mad-matrix repo) — merged.
- ESS proposal: <https://codeberg.org/b4mad/b4mad-matrix/src/branch/main/openspec/changes/replace-b4mad-matrix-with-ess/proposal.md>
- Cutover runbook: <https://codeberg.org/b4mad/b4mad-matrix/src/branch/main/docs/runbooks/cutover-day.md>
- Handoff runbook: <https://codeberg.org/b4mad/b4mad-matrix/src/branch/main/docs/runbooks/cnpg-cluster-ownership-handoff.md>