### PR TITLE
chore: scale legacy Matrix workloads to 0 (Phase 7 cutover)

### DIFF
--- a/manifests/applications/b4mad-matrix/dendrite/deployment.yaml
+++ b/manifests/applications/b4mad-matrix/dendrite/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: dendrite
 spec:
-  replicas: 1
+  replicas: 0
   strategy:
     type: Recreate
   template:

--- a/manifests/applications/b4mad-matrix/hookshot/deployment.yaml
+++ b/manifests/applications/b4mad-matrix/hookshot/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: matrix-hookshot
 spec:
-  replicas: 1
+  replicas: 0
   strategy:
     type: Recreate
   template:

--- a/manifests/applications/b4mad-matrix/syncv3/deployment.yaml
+++ b/manifests/applications/b4mad-matrix/syncv3/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: sliding-sync
 spec:
-  replicas: 1
+  replicas: 0
   strategy:
     type: Recreate
   template:


### PR DESCRIPTION
## Summary

Phase 7 of the [ESS migration](https://codeberg.org/b4mad/b4mad-matrix/src/branch/main/openspec/changes/replace-b4mad-matrix-with-ess/proposal.md) cuts over from Dendrite to Synapse on `nostromo`. As the first chart-side step the three legacy Deployments are scaled to 0 via their source-of-truth manifests so each App's sync state stays consistent (auto-sync is OFF on all three pending Phase 9 cleanup).

## What this PR does

| App | Path | replicas |
|-----|------|----------|
| `b4mad-matrix-dendrite` | `manifests/applications/b4mad-matrix/dendrite/deployment.yaml` | `1` → `0` |
| `b4mad-matrix-hookshot` | `manifests/applications/b4mad-matrix/hookshot/deployment.yaml` | `1` → `0` |
| `b4mad-matrix-syncv3` | `manifests/applications/b4mad-matrix/syncv3/deployment.yaml` | `1` → `0` |

The new ESS workloads (Synapse, MAS, Element Admin, chart-managed Hookshot) are deployed by the new `b4mad-matrix` App from the `codeberg.org/b4mad/b4mad-matrix` repo (PR #98 of this repo, already merged).

## What this PR does NOT change

- Ingresses, Services, PVCs, namespace, CNPG resources — all stay intact.
- CNPG `Cluster prod` Postgres data — untouched. Databases `matrix` (Dendrite), `hookshot`, `syncv3` retain their data; new `synapse` and `mas` databases live alongside.
- The three legacy Apps are NOT deleted here — Phase 9 retires them as a unit after the new stack is proven stable.

## After merge — operator actions

```bash
# Pick up the new replicas: 0 in each App's source
argocd app sync b4mad-matrix-dendrite --resource ',Deployment:b4mad-matrix/dendrite'
argocd app sync b4mad-matrix-hookshot --resource ',Deployment:b4mad-matrix/hookshot'
argocd app sync b4mad-matrix-syncv3   --resource ',Deployment:b4mad-matrix/syncv3'

# Verify all three Deployments are at 0/0
oc -n b4mad-matrix get deploy dendrite hookshot syncv3
```

Then continue Phase 7 of `cutover-day.md` Step 3 onwards (sync the new b4mad-matrix App, verify chart Pods, .well-known, federation, sign-in).

## Rollback

```bash
git revert <merge-commit-sha>
git push
# Sync each App once to bring legacy Deployments back to replicas: 1
```

Federation falls back to Dendrite within ~30 seconds (server_name b4mad.net unchanged; .well-known still points at matrix.erdgeschoss.b4mad.net:443).

## Related

- ESS proposal: <https://codeberg.org/b4mad/b4mad-matrix/src/branch/main/openspec/changes/replace-b4mad-matrix-with-ess/proposal.md>
- Cutover runbook: <https://codeberg.org/b4mad/b4mad-matrix/src/branch/main/docs/runbooks/cutover-day.md>
- #97 (released CNPG cluster to b4mad-matrix repo) — merged
- #98 (registered new b4mad-matrix App) — merged