### PR TITLE
chore: release b4mad-matrix Namespace to b4mad-matrix repo

### DIFF
--- a/manifests/applications/b4mad-matrix/dendrite/kustomization.yaml
+++ b/manifests/applications/b4mad-matrix/dendrite/kustomization.yaml
@@ -9,7 +9,6 @@ commonLabels:
   app.kubernetes.io/component: dendrite
 
 resources:
-  - namespace.yaml
   - serviceaccount.yaml
 
   # postgresql.yaml + aws-creds.yaml released to codeberg.org/b4mad/b4mad-matrix


### PR DESCRIPTION
## Summary

Continues the cross-repo ownership handoff to the new ESS [`b4mad-matrix`](https://codeberg.org/b4mad/b4mad-matrix) App. Same pattern as #97 (CNPG cluster) and #98 (App registration): unhook `namespace.yaml` from the dendrite Kustomization so the existing `b4mad-matrix-dendrite` App stops claiming ownership of the live Namespace.

The `b4mad-matrix` App from the new repo already includes `namespace.yaml` at its kustomize source root. Without this PR, both Apps would write the `argocd.argoproj.io/tracking-id` annotation on the Namespace on every sync.

## What this PR does

- `manifests/applications/b4mad-matrix/dendrite/kustomization.yaml` — drop the `- namespace.yaml` line.
- The file `namespace.yaml` is kept on disk for git history; deletion happens in Phase 9 wholesale.

## Pre-merge safety (already applied to live cluster)

- [x] `Namespace b4mad-matrix` annotated `argocd.argoproj.io/sync-options: Prune=false` so the existing App cannot delete it after this commit lands.
- [x] `b4mad-matrix-dendrite` App already has `spec.syncPolicy.automated` removed (sync is manual until Phase 9).

## After merge — operator actions

```bash
# Sync the existing App once. Namespace will show OutOfSync (extra
# resource not in source); Prune=false annotation blocks deletion.
argocd app sync b4mad-matrix-dendrite

# Sync the new b4mad-matrix App. Tracking-id flips on the live Namespace.
argocd app sync b4mad-matrix --resource ',Namespace::b4mad-matrix'
```

## What this PR does NOT change

- The Namespace itself stays exactly as it is on the live cluster.
- All workloads in `b4mad-matrix` ns continue running unchanged.
- No data is touched.

## Rollback

```bash
git revert <merge-commit-sha>
git push
```

The `Prune=false` annotation on the live Namespace remains the safety net throughout.

## Related

- ESS proposal: <https://codeberg.org/b4mad/b4mad-matrix/src/branch/main/openspec/changes/replace-b4mad-matrix-with-ess/proposal.md>
- Cutover runbook: <https://codeberg.org/b4mad/b4mad-matrix/src/branch/main/docs/runbooks/cutover-day.md>
- Handoff runbook: <https://codeberg.org/b4mad/b4mad-matrix/src/branch/main/docs/runbooks/cnpg-cluster-ownership-handoff.md>
- #97 (released CNPG cluster) — merged
- #98 (registered new App) — merged
- #99 (scaled legacy Deployments to 0) — merged