### PR TITLE
chore: drop legacy b4mad-matrix-hookshot App from parent kustomization

### DIFF
--- a/manifests/applications/op1st-gitops/kustomization.yaml
+++ b/manifests/applications/op1st-gitops/kustomization.yaml
@@ -22,7 +22,6 @@ resources:
   - applications/b4mad-epaper-service.yaml
   - applications/b4mad-epaper-service-tekton-secrets.yaml
   - applications/b4mad-matrix.yaml
-  - applications/b4mad-matrix-hookshot.yaml
   - applications/b4mad-keycloak.yaml
   - applications/b4mad-meshtastic-gateway.yaml
   - applications/b4mad-racing.yaml


### PR DESCRIPTION
Phase 7 cutover follow-up. The legacy Hookshot bridge is replaced by the chart-managed Hookshot in the new b4mad-matrix App (PR #98). selfHeal: true on the legacy App was reverting the cutover Ingress deletes; this PR removes it from the parent kustomization so any periodic re-apply stops recreating it.

The legacy resources (Deployment, Service, Ingress) stay on disk for git history and are removed wholesale in Phase 9 after Synapse stability is proven for 24h+.

## Test plan

- [ ] After merge: any external mechanism that applies the parent kustomization no longer re-applies b4mad-matrix-hookshot.yaml.
- [ ] Operator manually deletes the live Application CR and the orphaned hookshot.matrix.erdgeschoss.b4mad.net Ingress; they stay deleted.

## Related

- #97 (release CNPG cluster) — merged
- #98 (register new b4mad-matrix App) — merged
- #99 (scale legacy Deployments to 0) — merged
- #100 (release Namespace) — merged
