### PR TITLE
fix(b4mad-renovate): persist containerbase cache + npm host rules

### DIFF
--- a/manifests/applications/b4mad-renovate/config.yaml
+++ b/manifests/applications/b4mad-renovate/config.yaml
@@ -15,6 +15,16 @@ data:
           "install-tool node",
           "make readme"
         ],
+        "hostRules": [
+          {
+            "matchHost": "registry.npmjs.org",
+            "timeout": 60000
+          },
+          {
+            "matchHost": "github.com",
+            "timeout": 60000
+          }
+        ],
         "repositories": [
           "b4mad/hash-B4mad-op1st",
           "b4mad/hugo.containerimage",

--- a/manifests/applications/b4mad-renovate/cronjob.yaml
+++ b/manifests/applications/b4mad-renovate/cronjob.yaml
@@ -43,4 +43,5 @@ spec:
               secret:
                 secretName: ssh-key-secret
             - name: cache
-              emptyDir: {}
+              persistentVolumeClaim:
+                claimName: renovate-cache

--- a/manifests/applications/b4mad-renovate/kustomization.yaml
+++ b/manifests/applications/b4mad-renovate/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - cronjob.yaml
   - environment.yaml
   - namespace.yaml
+  - pvc.yaml
   - resource_quota.yaml
 
 images:

--- a/manifests/applications/b4mad-renovate/pvc.yaml
+++ b/manifests/applications/b4mad-renovate/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: renovate-cache
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi


### PR DESCRIPTION
## Summary

- Replace `emptyDir` cache with a `ReadWriteOnce` 5 Gi PVC so the containerbase Node toolchain survives between hourly cron runs.
- Add `hostRules` for `registry.npmjs.org` and `github.com` (60 s timeout) so npm lookups and containerbase artifact downloads do not silently time out.
- Register the new `pvc.yaml` in `kustomization.yaml`.

## Why

All open `@b4mad-renovate` PRs against `goern/epaper-service` carry the comment:

> ⚠️ Artifact update problem — File name: `web/package-lock.json`
> ```
> undefined
> ```

`undefined` is the tell that the inner npm command never executed (no stderr captured). The renovate image (`docker.io/renovate/renovate:43.168`) ships with node+npm and `binarySource: install` is already set — but the cache volume is `emptyDir`, so containerbase re-downloads Node + npm every `@hourly` run. One transient egress hiccup breaks lockfile re-solving for the whole run; the PR ships `package.json` change without a matching `package-lock.json` regen and `npm ci` in CI rejects it.

Tracking:
- Codeberg issue: https://codeberg.org/goern/epaper-service/issues/15
- Bead: `epaper-service-g1t` (P1, bug) — parent `epaper-service-2vy`

## Changes

| File | Change |
|---|---|
| `manifests/applications/b4mad-renovate/pvc.yaml` (new) | RWO 5 Gi PVC `renovate-cache` |
| `manifests/applications/b4mad-renovate/cronjob.yaml` | Bind `cache` volume to the PVC instead of `emptyDir` |
| `manifests/applications/b4mad-renovate/config.yaml` | Add `hostRules` for `registry.npmjs.org` and `github.com` |
| `manifests/applications/b4mad-renovate/kustomization.yaml` | Include `pvc.yaml` in resources |

`concurrencyPolicy: Forbid` is already set on the CronJob, so RWO single-writer is safe.

## Verification

Locally:

```
$ kustomize build manifests/applications/b4mad-renovate/
# (no errors; PVC and claimName wire through correctly)
```

After this merges:

1. Wait for next `@hourly` renovate run, or trigger manually.
2. Tick the *rebase/retry* box on https://codeberg.org/goern/epaper-service/pulls/11 (or rename title to start with `rebase!`).
3. Expected: the new PR diff contains a fully re-solved `web/package-lock.json` (multiple blocks updated, integrity hashes new) and no "Artifact update problem" follow-up comment.

## Test plan

- [ ] `kustomize build` clean
- [ ] ArgoCD sync without errors
- [ ] PVC `renovate-cache` bound on `b4mad-renovate` namespace
- [ ] Renovate cron pod log shows `install-tool node` finishing without redownload after first run
- [ ] Next renovate-generated PR on `goern/epaper-service/web/*` ships a clean `package-lock.json`

## Follow-ups not in this PR

- Surface renovate logs centrally (`LOG_LEVEL` is set in the sealed secret but the cron pod log is the only place it lands today).
- Decide whether to also broaden `allowedCommands` if any package manager needs custom post-upgrade steps (not required for npm lockfile updates).
- Repo-side: `goern/epaper-service/renovate.json5` still needs grouping rules for npm majors — separate change.