### PR TITLE
fix(pac): use tekton.dev/v1 in console URLs

### DIFF
--- a/manifests/applications/op1st-pipelines/kustomization.yaml
+++ b/manifests/applications/op1st-pipelines/kustomization.yaml
@@ -59,9 +59,9 @@ patches:
                 custom-console-url: >-
                   https://console-openshift-console.apps.nostromo.erdgeschoss.b4mad.emea.operate-first.cloud
                 custom-console-url-pr-details: >-
-                  https://console-openshift-console.apps.nostromo.erdgeschoss.b4mad.emea.operate-first.cloud/k8s/ns/{{ namespace }}/tekton.dev~v1beta1~PipelineRun/{{ pr }}
+                  https://console-openshift-console.apps.nostromo.erdgeschoss.b4mad.emea.operate-first.cloud/k8s/ns/{{ namespace }}/tekton.dev~v1~PipelineRun/{{ pr }}
                 custom-console-url-pr-tasklog: >-
-                  https://console-openshift-console.apps.nostromo.erdgeschoss.b4mad.emea.operate-first.cloud/k8s/ns/{{ namespace }}/tekton.dev~v1beta1~PipelineRun/{{ pr }}/logs/{{ task }}
+                  https://console-openshift-console.apps.nostromo.erdgeschoss.b4mad.emea.operate-first.cloud/k8s/ns/{{ namespace }}/tekton.dev~v1~PipelineRun/{{ pr }}/logs/{{ task }}
         pruner:
           resources:
             - taskrun


### PR DESCRIPTION
## Summary

PaC stamps every PipelineRun with a `log-url` annotation derived from `custom-console-url-pr-details` / `custom-console-url-pr-tasklog` in `manifests/applications/op1st-pipelines/kustomization.yaml`. These templates currently encode `tekton.dev~v1beta1~PipelineRun`, but `PipelineRun` is served as `tekton.dev/v1` on this cluster.

Result: "Details" links from PaC commit statuses 404 in the OpenShift console.

Example bad link from a real run (PR https://codeberg.org/goern/forgejo-mcp/pulls/131):

```
https://console-openshift-console.apps.nostromo.erdgeschoss.b4mad.emea.operate-first.cloud/k8s/ns/op1st-pipelines/tekton.dev~v1beta1~PipelineRun/openspec-validate-pr-t5khd
```

vs the working v1 path:

```
https://console-openshift-console.apps.nostromo.erdgeschoss.b4mad.emea.operate-first.cloud/k8s/ns/op1st-pipelines/tekton.dev~v1~PipelineRun/openspec-validate-pr-t5khd
```

## Change

Two-string swap in `manifests/applications/op1st-pipelines/kustomization.yaml`: `tekton.dev~v1beta1~PipelineRun` -> `tekton.dev~v1~PipelineRun` in both URL templates.

## Test plan

- [x] PipelineRun on cluster confirmed at `apiVersion: tekton.dev/v1`
- [x] PaC ConfigMap `openshift-pipelines/pipelines-as-code` will receive new values via TektonInstallerSet after ArgoCD sync
- [ ] After merge + sync, trigger a fresh PaC run and click the "Details" link from the commit status -- should resolve to the v1 console page
- [ ] Existing PipelineRuns keep stale v1beta1 links (annotation already written); only new runs benefit

## Notes

PaC version `v0.39.5` (per ConfigMap label). Newer PaC versions emit v1 by default; this override is what is controlling the value here, not the upstream default.