### PR TITLE
feat(op1st): enable auto-sync on b4mad-matrix Application

### DIFF
--- a/manifests/applications/op1st-gitops/applications/b4mad-matrix.yaml
+++ b/manifests/applications/op1st-gitops/applications/b4mad-matrix.yaml
@@ -13,11 +13,25 @@
 #      existing Cluster `prod` CR from b4mad-matrix-dendrite to this
 #      Application via the tracking-id annotation.
 #
-# Auto-sync deliberately UNSET until the Phase 7 cutover is proven; see
-# docs/runbooks/cutover-day.md in the b4mad-matrix repo. After Phase 10
-# lockdown set:
-#   syncPolicy.automated.prune: false
-#   syncPolicy.automated.selfHeal: false
+# Auto-sync enabled after Phase 7 cutover stabilised (2026-05-16).
+#
+# Full-autonomy posture: prune=true, selfHeal=true. The cluster is a
+# pure projection of git. Safety belts are applied per-resource via
+# `argocd.argoproj.io/sync-options: Prune=false` on every stateful or
+# load-bearing resource in the b4mad-matrix repo:
+#   - namespace.yaml                         (cascade-delete protection)
+#   - sealed-secrets/*.yaml (4 SealedSecrets)
+#   - cnpg/cluster.yaml (Cluster, Pooler, ScheduledBackup)
+#   - cnpg/databases/{synapse,mas}.yaml
+# Stateless resources (hookshot-smoke ConfigMap + CronJob, chart-owned
+# Deployments/Services/Ingresses) are intentionally NOT pinned — they
+# re-derive from git on next sync.
+#
+# Operational consequence of selfHeal=true: any cluster-side `oc patch`
+# or `oc edit` against a chart-managed resource reverts within ~60s.
+# For an incident hotfix that must persist, either commit the change to
+# git, or temporarily annotate the target with
+# `argocd.argoproj.io/sync-options: SelfHeal=false` before patching.
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
@@ -47,6 +61,9 @@ spec:
       targetRevision: HEAD
       path: .
   syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
     syncOptions:
       - CreateNamespace=false
       - ServerSideApply=true


### PR DESCRIPTION
## Summary

Flip `syncPolicy.automated` on `Application/b4mad-matrix` to `{prune: true, selfHeal: true}`. Phase 7 cutover stabilised 2026-05-16.

## Safety model

Per-resource `argocd.argoproj.io/sync-options: Prune=false` already in place on every stateful resource in [b4mad/b4mad-matrix@645b8ff](https://codeberg.org/b4mad/b4mad-matrix/commit/645b8ff):

- `Namespace/b4mad-matrix` (cascade-delete protection — CRITICAL)
- 4 SealedSecrets (`aws-creds`, `cnpg-role-{synapse,mas}`, `mas-keycloak-erdgeschoss-config`)
- CNPG `Cluster/prod` + `Pooler/prod-pooler` + `ScheduledBackup/prod-daily`
- `Database/{synapse,mas}`

Stateless resources (Hookshot smoke `ConfigMap`+`CronJob`, chart-owned Deployments/Services/Ingresses) intentionally NOT pinned — re-derive from git on every sync.

## Operational consequence

`selfHeal: true` means cluster-side `oc patch` / `oc edit` against any chart-managed resource reverts within ~60s. Persistent hotfix path:
1. commit to git, **or**
2. temporarily annotate target with `argocd.argoproj.io/sync-options: SelfHeal=false` before patching.

## Test plan

- [ ] `oc -n op1st-gitops get application b4mad-matrix -o jsonpath='{.spec.syncPolicy.automated}'` returns `{"prune":true,"selfHeal":true}` post-merge
- [ ] Push a no-op commit to `codeberg.org/b4mad/b4mad-matrix` and confirm ArgoCD auto-syncs within ~3 minutes
- [ ] `oc -n b4mad-matrix get cluster prod -o jsonpath='{.metadata.annotations.argocd\.argoproj\.io/sync-options}'` confirms `Prune=false` belt is honoured

Tracked: bd `b4mad-matrix-dmz`.