### PR TITLE
feat(op1st): ignore CNPG operator-owned fields on Cluster/prod

### DIFF
--- a/manifests/applications/op1st-gitops/applications/b4mad-matrix.yaml
+++ b/manifests/applications/op1st-gitops/applications/b4mad-matrix.yaml
@@ -46,6 +46,17 @@ spec:
   destination:
     name: nostromo
     namespace: b4mad-matrix
+  # CNPG operator owns ~40 fields on Cluster spec via server-side apply
+  # (postgresql.parameters, replicationSlots, postgresUID/GID, probes,
+  # affinity, etc.) — all admission-time defaults, not human edits.
+  # Without this block ArgoCD reports the Cluster CR OutOfSync forever
+  # and selfHeal retries every reconcile against the CNPG operator,
+  # producing constant churn with no observable effect.
+  ignoreDifferences:
+    - group: postgresql.cnpg.io
+      kind: Cluster
+      managedFieldsManagers:
+        - cloudnative-pg
   sources:
     - repoURL: ghcr.io/element-hq/ess-helm
       chart: matrix-stack


### PR DESCRIPTION
## Summary

Adds `spec.ignoreDifferences` to `Application/b4mad-matrix` so ArgoCD stops fighting the CNPG operator over its admission-time defaults.

## Problem

After merging #104 (auto-sync), `Cluster/prod` reports **OutOfSync / Healthy** permanently. Diff between git and live shows ~40 fields:

- `spec.postgresql.parameters.*` (archive_mode, wal_*, ssl_*, logging_*, etc.)
- `spec.replicationSlots`, `spec.probes`, `spec.affinity`
- `spec.postgresGID`, `spec.postgresUID`
- `spec.primaryUpdate{Method,Strategy}`, `spec.{start,stop,smartShutdown,switchover,failover}Delay`
- `spec.managed.roles[]` — operator fills `connectionLimit: -1, inherit: true` on legacy `dendrite`/`syncv3`/`hookshot` roles

None are human edits. All are CNPG operator defaults applied via SSA after Cluster CR admission. selfHeal=true was retrying these on every reconcile against the operator's field ownership — pure churn.

## Fix

```yaml
ignoreDifferences:
  - group: postgresql.cnpg.io
    kind: Cluster
    managedFieldsManagers:
      - cloudnative-pg
```

Tells ArgoCD: anything the `cloudnative-pg` SSA field manager owns is not our concern. Cleaner than enumerating ~40 jsonPointers — automatically tracks new CNPG defaults across operator upgrades.

## Test plan

- [ ] Post-merge: `oc -n op1st-gitops get application b4mad-matrix -o jsonpath='{.status.sync.status}'` returns `Synced`
- [ ] `oc -n op1st-gitops get application b4mad-matrix -o jsonpath='{.status.resources[?(@.kind=="Cluster")].status}'` returns `Synced`
- [ ] Push a no-op commit to `codeberg.org/b4mad/b4mad-matrix`; confirm next sync completes without Cluster drift reappearing