### PR TITLE
fix(op1st): use jsonPointers for CNPG Cluster ignoreDifferences

### DIFF
--- a/manifests/applications/op1st-gitops/applications/b4mad-matrix.yaml
+++ b/manifests/applications/op1st-gitops/applications/b4mad-matrix.yaml
@@ -49,14 +49,37 @@ spec:
   # CNPG operator owns ~40 fields on Cluster spec via server-side apply
   # (postgresql.parameters, replicationSlots, postgresUID/GID, probes,
   # affinity, etc.) — all admission-time defaults, not human edits.
-  # Without this block ArgoCD reports the Cluster CR OutOfSync forever
-  # and selfHeal retries every reconcile against the CNPG operator,
-  # producing constant churn with no observable effect.
+  #
+  # We previously tried managedFieldsManagers: [cloudnative-pg], but the
+  # CNPG operator (verified on nostromo with `oc get cluster prod
+  # --show-managed-fields`) sets its SSA field manager to the literal
+  # string `manager` — Go's zero-value default. Filtering on `manager`
+  # would catch any other generic SSA client too, so jsonPointers are
+  # cleaner: explicit and stable across operator upgrades.
   ignoreDifferences:
     - group: postgresql.cnpg.io
       kind: Cluster
-      managedFieldsManagers:
-        - cloudnative-pg
+      jsonPointers:
+        - /spec/affinity
+        - /spec/bootstrap
+        - /spec/enablePDB
+        - /spec/enableSuperuserAccess
+        - /spec/failoverDelay
+        - /spec/logLevel
+        - /spec/maxSyncReplicas
+        - /spec/minSyncReplicas
+        - /spec/postgresGID
+        - /spec/postgresUID
+        - /spec/postgresql
+        - /spec/primaryUpdateMethod
+        - /spec/primaryUpdateStrategy
+        - /spec/probes
+        - /spec/replicationSlots
+        - /spec/resources
+        - /spec/smartShutdownTimeout
+        - /spec/startDelay
+        - /spec/stopDelay
+        - /spec/switchoverDelay
   sources:
     - repoURL: ghcr.io/element-hq/ess-helm
       chart: matrix-stack


### PR DESCRIPTION
## Summary

Replaces the `managedFieldsManagers: [cloudnative-pg]` filter from #105 with explicit `jsonPointers`. The filter caught nothing because CNPG operator writes SSA fields as field manager **`manager`** (Go zero-value default), not `cloudnative-pg` — verified on nostromo:

```bash
$ oc -n b4mad-matrix get cluster prod --show-managed-fields -o yaml | grep '^\s*manager:' | sort -u
manager: argocd-controller
    manager: kubectl-annotate
    manager: kubectl-label
    manager: manager
```

Filtering on the literal `manager` would catch any generic Go SSA client — too broad. jsonPointers are explicit and stable across CNPG operator upgrades.

## Changes

- 21 jsonPointers covering CNPG admission-time fills: postgresql.parameters, replicationSlots, postgresUID/GID, probes, affinity, primaryUpdate{Method,Strategy}, {start,stop,smartShutdown,switchover,failover}Delay, etc.
- **`/spec/managed/roles` deliberately NOT in the ignore list.** Future role changes must still trigger drift detection. The legacy role defaults (`inherit: true`, `connectionLimit: -1`) are materialised explicitly in the source repo: [b4mad/b4mad-matrix@7e24334](https://codeberg.org/b4mad/b4mad-matrix/commit/7e24334).

## Test plan

- [ ] Post-merge: `oc -n op1st-gitops get application b4mad-matrix -o jsonpath='{.status.sync.status}'` returns `Synced`
- [ ] All resources Synced including Cluster/prod
- [ ] Modifying a managed role in b4mad-matrix repo still triggers OutOfSync (drift detection retained)