### PR TITLE
fix: 🐛 raise argocd repo-server memory to stop OOMKill flap

### DIFF
--- a/manifests/applications/op1st-gitops/argocd.yaml
+++ b/manifests/applications/op1st-gitops/argocd.yaml
@@ -91,11 +91,11 @@ spec:
   repo:
     resources:
       limits:
-        cpu: 200m
-        memory: 256Mi
+        cpu: 500m
+        memory: 1Gi
       requests:
-        cpu: 50m
-        memory: 128Mi
+        cpu: 100m
+        memory: 256Mi
   extraConfig:
     timeout.reconciliation: 600s
   resourceExclusions: |


### PR DESCRIPTION
## Root cause

The `op1st-gitops` `argocd-repo-server` was **OOMKilled** (exit 137) — restarted **33 times** at a **256Mi** memory limit while serving ~a dozen repos (feeldata, epaper-service, hausmeister, radicle, op1st-emea-b4mad, castra, …).

During each restart the application-controller cannot dial it:

```
ComparisonError: dial tcp 172.30.72.213:8081: connect: connection refused
```

so **every** Application flaps to `ComparisonError` / `sync: Unknown` and renders as Degraded in the UI. Observed on `b4mad-castra` (namespace stayed empty because no manifest ever rendered), but it is cluster-wide, not app-specific.

## Fix

Bump the repo-server resources on the `argocd` CR:

| | before | after |
|---|---|---|
| limits.memory | 256Mi | **1Gi** |
| limits.cpu | 200m | 500m |
| requests.memory | 128Mi | 256Mi |
| requests.cpu | 50m | 100m |

## Notes

A pod-level `oc rollout restart deploy/argocd-repo-server -n op1st-gitops` clears the immediate flap; this PR makes the headroom durable so the operator doesn't revert it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TNqstm1ydJ6UVnNTvDBNZZ