### PR TITLE
fix: 🔐 grant application-controller RBAC for ValidatingAdmissionPolicy

### DIFF
--- a/manifests/environments/nostromo/openshift-gitops/rbac/openshift-gitops-integration.yaml
+++ b/manifests/environments/nostromo/openshift-gitops/rbac/openshift-gitops-integration.yaml
@@ -76,6 +76,8 @@ rules:
     resources:
       - mutatingwebhookconfigurations
       - validatingwebhookconfigurations
+      - validatingadmissionpolicies
+      - validatingadmissionpolicybindings
     verbs:
       - create
       - delete


### PR DESCRIPTION
## Problem

`environment-nostromo` can never reach `Synced`. Two of its 147 managed resources are RBAC-denied:

```
ValidatingAdmissionPolicy/cronjob-timezone-utc-only         OutOfSync
ValidatingAdmissionPolicyBinding/cronjob-timezone-utc-only  OutOfSync
```

```
Failed to perform client-side apply migration for
{admissionregistration.k8s.io ValidatingAdmissionPolicy cronjob-timezone-utc-only}:
validatingadmissionpolicies.admissionregistration.k8s.io "cronjob-timezone-utc-only"
is forbidden: User "system:serviceaccount:openshift-gitops:openshift-gitops-argocd-application-controller"
cannot patch resource "validatingadmissionpolicies" in API group
"admissionregistration.k8s.io" at the cluster scope
```

Because `syncPolicy.automated.selfHeal: true`, this is a **closed loop**: app is `OutOfSync` -> selfHeal syncs -> the same two resources fail -> still `OutOfSync` -> sync again.

Measured on nostromo, 30-minute window:

| | |
|---|---|
| `Adding resource result` log lines | 580, all `application=environment-nostromo` |
| full syncs | 4 (`syncId` 00022-00025), **145 resources each** |
| cadence | one complete re-apply every ~7 min, indefinitely |

This was a meaningful share of `openshift-gitops-application-controller-0` CPU (674m at peak, alongside a separate, now-fixed CRD-churn problem).

## Cause

`openshift-gitops-openshift-gitops-argocd-application-controller` -- the controller's bound ClusterRole -- grants `*`/`*` for **`get,list,watch` only**. Write verbs are enumerated per API group. `admissionregistration.k8s.io` writes come from `openshift-gitops-environment-manager-role` in this file, which listed only the two webhook-configuration resources.

Verified against the live cluster:

```
validatingadmissionpolicies         get=yes  patch=no  update=no  create=no
validatingadmissionpolicybindings   get=yes  patch=no  update=no  create=no
```

Both `patch` and `update` are needed -- ArgoCD's client-side-apply migration path patches the existing object. These objects predate SSA and carry no `last-applied-configuration` annotation, which is what triggers the migration.

## Change

Adds `validatingadmissionpolicies` and `validatingadmissionpolicybindings` to the existing `admissionregistration.k8s.io` rule. Verbs unchanged.

**No new privilege exposure**: this ClusterRole already carries `rbac.authorization.k8s.io: ["*"]` with verbs `["*"]`, which is full escalation.

## Verification

- `yaml.safe_load_all` parses.
- `oc apply --dry-run=server` accepts all five objects in the file.
- `pre-commit run --files <file>` passes.

Post-merge check -- the loop should stop and the app reach `Synced`:

```bash
oc -n openshift-gitops get app environment-nostromo -o jsonpath='{.status.sync.status}{"\n"}'
oc -n openshift-gitops logs openshift-gitops-application-controller-0 --since=15m \
  | grep -c 'Adding resource result'   # expect a small number, not ~290
oc -n openshift-gitops adm top pod openshift-gitops-application-controller-0
```
