### PR TITLE
chore: 🔧 stagger CNPG backup schedules to spread nightly load

### DIFF
--- a/manifests/applications/b4mad-forgejo/postgresql.yaml
+++ b/manifests/applications/b4mad-forgejo/postgresql.yaml
@@ -74,7 +74,10 @@ kind: ScheduledBackup
 metadata:
   name: daily
 spec:
-  schedule: "0 0 3 * * *"
+  # 05:00 — staggered to spread nostromo's nightly CNPG backup load. Cluster-wide
+  # slots: 02:00 pipelines, 02:30 keycloak, 03:00 feeldata-stage, 04:00 feeldata
+  # dev+prod, 04:30 matrix, 05:00 forgejo, 06:00 machdenstaat.
+  schedule: "0 0 5 * * *"
   backupOwnerReference: self
   cluster:
     name: prod

--- a/manifests/applications/b4mad-keycloak/postgresql.yaml
+++ b/manifests/applications/b4mad-keycloak/postgresql.yaml
@@ -84,7 +84,10 @@ kind: ScheduledBackup
 metadata:
   name: daily
 spec:
-  schedule: "0 0 3 * * *"
+  # 02:30 — staggered to spread nostromo's nightly CNPG backup load. Cluster-wide
+  # slots: 02:00 pipelines, 02:30 keycloak, 03:00 feeldata-stage, 04:00 feeldata
+  # dev+prod, 04:30 matrix, 05:00 forgejo, 06:00 machdenstaat.
+  schedule: "0 30 2 * * *"
   backupOwnerReference: self
   cluster:
     name: postgresql


### PR DESCRIPTION
## Why

Auditing all ScheduledBackup resources on nostromo showed backups clumping:

| Time | Backups | Repo |
|---|---|---|
| 02:00 | openshift-pipelines (tekton-results) | this repo |
| **03:00** | **forgejo + keycloak + feeldata-stage** | this repo ×2, feeldata |
| 04:00 | feeldata-dev + feeldata-prod | feeldata |
| 04:30 | matrix | b4mad-matrix |
| 06:00 | machdenstaat-oparl-lite-stage | machdenstaat |

Three concurrent base backups + WAL archiving to S3 at 03:00 is the load spike.

## What

Move the two backups **this repo owns** out of the 03:00 hotspot into empty gaps:

- `b4mad-keycloak/daily`: `0 0 3` → `0 30 2` (03:00 → 02:30)
- `b4mad-forgejo/daily`: `0 0 3` → `0 0 5` (03:00 → 05:00)

Resulting nostromo-wide timeline — peak concurrency **3 → 2**:

```
02:00 pipelines
02:30 keycloak      ← moved
03:00 feeldata-stage
04:00 feeldata dev + prod
04:30 matrix
05:00 forgejo       ← moved
06:00 machdenstaat
```

## Out of scope (other repos)

The remaining 04:00 double is feeldata's own dev+prod, in `codeberg.org/feeldata/manifests` — recommend their owner move one to ~05:30 to fully de-collide. matrix (04:30) and machdenstaat (06:00) are already solo; left untouched.

## Validation

`oc apply --dry-run=server` accepts both edited ScheduledBackups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)