### PR TITLE
chore: 🔧 disable Renovate for all machdenstaat repos on Codeberg

### DIFF
--- a/manifests/applications/b4mad-renovate/config.yaml
+++ b/manifests/applications/b4mad-renovate/config.yaml
@@ -39,10 +39,10 @@ data:
           "goern/epaper-service",
           "goern/forgejo-mcp",
           "goern/hausmeister",
-          "goern/sops2sealedsecret",
-          "machdenstaat/lage",
-          "machdenstaat/oparl-lite-2",
-          "machdenstaat/stadt-bonn-oparl"
+          "goern/sops2sealedsecret"
+          // machdenstaat/* removed 2026-07-28: renovate disabled for the whole
+          // org on operator request. Was lage, oparl-lite-2, stadt-bonn-oparl.
+          // These repos now receive NO dependency updates until re-enrolled.
           // toolbxs/* removed 2026-07-28: forgejo.b4mad.net is primary for that
           // org and codeberg is a push-mirror downstream. Renovating the mirror
           // would fight the mirror-push. Re-enrol against the Forgejo endpoint.


### PR DESCRIPTION
Removes `machdenstaat/lage`, `machdenstaat/oparl-lite-2` and `machdenstaat/stadt-bonn-oparl` from the Codeberg Renovate fleet (`config.yaml`).

Enrolment is an explicit list (no `autodiscover`), so dropping the entries is what disables the bot for the org.

Verified with `oc kustomize`.

Left untouched (deliberate, needs a decision): 12 open Renovate PRs and 3 Dependency Dashboard issues across the three repos will go stale. These repos are not enrolled in the Forgejo fleet either, so they now get no dependency updates at all.