### PR TITLE
chore: 🔧 disable Renovate for all feeldata repos on Codeberg

### DIFF
--- a/manifests/applications/b4mad-renovate/config.yaml
+++ b/manifests/applications/b4mad-renovate/config.yaml
@@ -29,8 +29,10 @@ data:
           "b4mad/hash-B4mad-op1st",
           "b4mad/hugo.containerimage",
           "b4mad/semantic-release",
-          "feeldata/feeldata2.app",
-          "feeldata/manifests",
+          // feeldata/* removed 2026-07-28: the org is being migrated off
+          // codeberg.org, so renovating the soon-to-be-stale copy is wasted
+          // work. Was feeldata2.app and manifests. These repos receive NO
+          // dependency updates until re-enrolled against the new forge.
           // goern/cccr removed 2026-07-28: the repo no longer exists on
           // codeberg.org. Renovate logged 2x "The target couldn't be found."
           // (404) against it; an authenticated repo search with an admin


### PR DESCRIPTION
## What

Drops `feeldata/feeldata2.app` and `feeldata/manifests` from the Codeberg Renovate fleet (`manifests/applications/b4mad-renovate/config.yaml`).

## Why

The feeldata org is being migrated off codeberg.org. Renovating a copy that is about to go stale produces PRs nobody will merge.

## Consequence

Both repos receive **no** dependency updates and no CVE bumps until re-enrolled against the forge the org lands on. Same gap shape as b4mad/op1st-emea-b4mad#113 (machdenstaat) and the toolbxs drop.

## Not in this PR

- `manifests/applications/op1st-gitops/kustomization.yaml` still pulls Argo Applications live from `codeberg.org/feeldata/manifests/raw/branch/main/applications/{dev,prod}.yaml` — a live input to nostromo that must be repointed at cutover.
- `manifests/environments/nostromo/gatekeeper/constraints.yaml` still allowlists `codeberg.org/feeldata`.