### PR TITLE
feat: ✨ renovate feeldata2.app on the Forgejo fleet

### DIFF
--- a/manifests/applications/b4mad-renovate/config-forgejo.yaml
+++ b/manifests/applications/b4mad-renovate/config-forgejo.yaml
@@ -40,6 +40,13 @@ data:
         "autodiscover": true,
         "autodiscoverFilter": [
           "toolbxs/*",
-          "b4mad/*"
+          "b4mad/*",
+          // Deliberately ONE repo, not `feeldata/*`. The org migrated off
+          // codeberg.org on 2026-07-28 with four repos, but only feeldata2.app
+          // is to be renovated: feeldata.app is the superseded site,
+          // feeldata2.app-oooooold is archived, and manifests was never
+          // usefully onboarded (its Codeberg onboarding PR sat unmerged from
+          // 2025-01-05 until it was closed). Widen only on purpose.
+          "feeldata/feeldata2.app"
         ],
     };


### PR DESCRIPTION
## What

Adds `feeldata/feeldata2.app` to `autodiscoverFilter` in the Forgejo Renovate fleet (`config-forgejo.yaml`).

## Why

The `feeldata` org migrated from codeberg.org to forgejo.b4mad.net on 2026-07-28. All four repos now carry content on Forgejo, verified against the source:

| Repo | Head SHA | Branches | Issues | Visibility / archive |
|---|---|---|---|---|
| `feeldata.app` | match | 14/14 | 38/38 | public |
| `feeldata2.app` | match | 4/4 | 5/5 | private |
| `feeldata2.app-oooooold` | match | 4/4 | 21/21 | private, archived |
| `manifests` | match | 1/1 | 0/0 | public |

## Scope

**One repo, not `feeldata/*`** — deliberately. `feeldata.app` is the superseded site, `feeldata2.app-oooooold` is archived (so autodiscover would skip it anyway), and `manifests` was never usefully onboarded on Codeberg.

No duplicate-PR window: feeldata was removed from the Codeberg fleet in `df6a7c7` before this lands.

## Still open (`Systems-mul`, P0)

Neither of the live nostromo references is repointed yet:

- `op1st-gitops/kustomization.yaml:32-33` still fetches Argo Applications from `codeberg.org/feeldata/manifests`. The Forgejo raw URL is confirmed reachable unauthenticated (`200`).
- `gatekeeper/constraints.yaml` still allowlists only the `codeberg.org/feeldata` registry (`enforcementAction: warn`, so a miss is silent).