### PR TITLE
feat: ✨ fetch feeldata Argo Applications from Forgejo

### DIFF
--- a/manifests/applications/op1st-gitops/kustomization.yaml
+++ b/manifests/applications/op1st-gitops/kustomization.yaml
@@ -29,7 +29,10 @@ resources:
   - applications/b4mad-radicle.yaml
   - applications/b4mad-renovate.yaml
   - applications/hausmeister.yaml
-  - https://codeberg.org/feeldata/manifests/raw/branch/main/applications/dev.yaml
-  - https://codeberg.org/feeldata/manifests/raw/branch/main/applications/prod.yaml
+  # feeldata migrated off codeberg.org 2026-07-28; forgejo.b4mad.net is now
+  # primary. Kustomize fetches these at build time, so a bad URL here breaks
+  # the whole op1st-gitops build, not just feeldata.
+  - https://forgejo.b4mad.net/feeldata/manifests/raw/branch/main/applications/dev.yaml
+  - https://forgejo.b4mad.net/feeldata/manifests/raw/branch/main/applications/prod.yaml
   - https://codeberg.org/machdenstaat/oparl-lite-2/raw/branch/main/manifests/environment/stage/argocd-application.yaml
   - https://codeberg.org/machdenstaat/lage/raw/branch/main/manifest/environment/nostromo/argocd-app.yaml


### PR DESCRIPTION
## What

Repoints the two remote kustomize resources in `manifests/applications/op1st-gitops/kustomization.yaml` from `codeberg.org/feeldata/manifests` to `forgejo.b4mad.net/feeldata/manifests`.

## Why

The `feeldata` org migrated off codeberg.org on 2026-07-28 (content migration verified in `Systems-mul`; Renovate re-scoped in #115). This was the last live nostromo reference to the old forge.

## Verification

- Both Forgejo raw URLs return `200` unauthenticated and serve **byte-identical** content to the Codeberg originals (`diff` clean).
- `kustomize build manifests/applications/op1st-gitops` succeeds and renders **output identical** to the pre-change tree — only the fetch source moves, no manifest churn.
- 14 Argo Applications render, including `feeldata-dev` and `feeldata-prod`.

Kustomize resolves these at build time, so a bad URL breaks the entire op1st-gitops build rather than just feeldata — hence the local build check rather than relying on review alone.

## Note

The companion Gatekeeper allowlist change is **not needed**: Gatekeeper is no longer deployed on nostromo (no CRDs, no namespace). `manifests/environments/nostromo/gatekeeper/` is now dead config — tracked separately.