### PR TITLE
fix: manage feeldata-stage from GitOps

### DIFF
--- a/manifests/applications/op1st-gitops/kustomization.yaml
+++ b/manifests/applications/op1st-gitops/kustomization.yaml
@@ -32,7 +32,11 @@ resources:
   # feeldata migrated off codeberg.org 2026-07-28; forgejo.b4mad.net is now
   # primary. Kustomize fetches these at build time, so a bad URL here breaks
   # the whole op1st-gitops build, not just feeldata.
+  # stage.yaml was omitted here until 2026-07-28 while applications/stage.yaml
+  # existed in the repo, so feeldata-stage ran hand-applied and off GitOps --
+  # it was still pointing at codeberg.org after dev and prod had moved.
   - https://forgejo.b4mad.net/feeldata/manifests/raw/branch/main/applications/dev.yaml
+  - https://forgejo.b4mad.net/feeldata/manifests/raw/branch/main/applications/stage.yaml
   - https://forgejo.b4mad.net/feeldata/manifests/raw/branch/main/applications/prod.yaml
   - https://codeberg.org/machdenstaat/oparl-lite-2/raw/branch/main/manifests/environment/stage/argocd-application.yaml
   - https://codeberg.org/machdenstaat/lage/raw/branch/main/manifest/environment/nostromo/argocd-app.yaml


### PR DESCRIPTION
`applications/stage.yaml` has existed in the feeldata manifests repo all along but was never listed in this kustomization, so `feeldata-stage` ran **hand-applied** and off GitOps. It carries a `kubectl.kubernetes.io/last-applied-configuration` annotation and drifted: dev and prod moved to Forgejo in #116, stage was left pointing at codeberg.org.

Live state before this change:

```
feeldata-dev    https://forgejo.b4mad.net/feeldata/manifests.git   Synced Healthy
feeldata-prod   https://forgejo.b4mad.net/feeldata/manifests.git   Synced Healthy
feeldata-stage  https://codeberg.org/feeldata/manifests.git        Synced Healthy   <-- drift
```

Adding the raw URL lets ArgoCD adopt the live Application and repoint it, closing the last feeldata source still reading the old forge.

## Verification

`kustomize build manifests/applications/op1st-gitops` renders 15 Applications, all three feeldata apps now on Forgejo:

```
feeldata-dev    https://forgejo.b4mad.net/feeldata/manifests.git  environments/dev
feeldata-stage  https://forgejo.b4mad.net/feeldata/manifests.git  environments/stage
feeldata-prod   https://forgejo.b4mad.net/feeldata/manifests.git  environments/prod
```

## Context

Part of the feeldata CI move off Codeberg, alongside `feeldata/manifests#5` and `feeldata/feeldata2.app#71`. This PR is independent of those two and can merge on its own.

Related: `Systems-mul`, `Systems-emy` (untracked in-cluster objects).