### PR TITLE
fix: 🐛 allow Forgejo webhooks to reach the in-cluster PaC controller

### DIFF
--- a/manifests/applications/b4mad-forgejo/values-nostromo.yaml
+++ b/manifests/applications/b4mad-forgejo/values-nostromo.yaml
@@ -220,6 +220,36 @@ gitea:
       # button remains. NOTE: this also disables web login for the local
       # 'gitea_admin' account — break-glass is `oc exec … gitea admin …`.
       ENABLE_INTERNAL_SIGNIN: false
+    webhook:
+      # Allow webhook delivery to the in-cluster Pipelines-as-Code controller.
+      #
+      # Forgejo's default ALLOWED_HOST_LIST is `external`, which denies every
+      # private/loopback/link-local target. That is why PaC webhooks for
+      # forgejo-hosted repos silently stopped being delivered on 2026-07-28:
+      #
+      #   webhook can only call allowed HTTP servers (check your
+      #   webhook.ALLOWED_HOST_LIST setting), deny
+      #   'pipelines-as-code-controller-…(192.168.0.148:443)'
+      #
+      # 192.168.0.148 is this node's LAN address — the external route
+      # *.apps.nostromo… resolves there from inside the cluster, so the
+      # round-trip through the ingress is denied as "private".
+      #
+      # ⚠️ Forgejo and the PaC controller run in the SAME cluster, so repos
+      # hosted here should point their webhook at the internal Service
+      # (pipelines-as-code-controller.openshift-pipelines.svc.cluster.local:8080)
+      # rather than hairpinning through the public route. 172.30.0.0/16 is this
+      # cluster's serviceNetwork, which is what that name resolves to.
+      #
+      # `external` is kept first so outbound webhooks to real internet hosts
+      # keep working exactly as before — this widens the list, it does not
+      # replace it. Scoped to the service CIDR rather than the broader
+      # `private` category so a compromised repo cannot aim a webhook at the
+      # LAN.
+      #
+      # Codeberg-hosted repos are unaffected: they reach PaC from outside via
+      # the route, and never consult this setting.
+      ALLOWED_HOST_LIST: "external, 172.30.0.0/16"
 
 # Expose Forgejo's built-in git-SSH via a fixed NodePort so the erdgeschoss
 # gateway can forward external :2222 to it (no LoadBalancer/MetalLB on this


### PR DESCRIPTION
## Problem

Pipelines-as-Code webhook delivery from `forgejo.b4mad.net` broke at **22:34 on 2026-07-28**, mid-merge of `feeldata/feeldata2.app#70`. The merge landed; the push-to-main CI never ran.

```
Unable to deliver webhook task[74] ... due to error in http client:
dial tcp 192.168.0.148:443: webhook can only call allowed HTTP servers
(check your webhook.ALLOWED_HOST_LIST setting), deny
'pipelines-as-code-controller-...operate-first.cloud(192.168.0.148:443)'
```

Verified directly:

- `app.ini` has **no `[webhook]` section**, so `ALLOWED_HOST_LIST` is at its default `external`, which denies all private/loopback/link-local targets.
- From inside the Forgejo pod the PaC route resolves to `192.168.0.148` — this node's LAN address (the same one this file already documents as the SSH NodePort target).
- The push itself was fine (pre/post-receive 200). The PaC controller is Ready and its log shows **nothing** arriving. This is a delivery failure, not a PaC failure.

## ⚠️ What is *not* established

The pod is `forgejo-5d554b6d5d-2jhdr`, started 21:36:12, `restartCount=0` — the **same pod** that delivered successfully at 21:43–21:55 and failed at 22:34. Config never changed and was never re-read, so this is not a restart losing settings.

The mechanism is clear (a private resolved IP is refused under `external`), but **what changed the resolution between 22:00 and 22:34 is unproven.** Most likely the route previously resolved to the public gateway `88.153.142.188` and now answers with the LAN address. I have not demonstrated that, and this PR does not depend on it — the fix is correct either way, and in fact removes the dependency on that resolution entirely.

## The change

```yaml
gitea:
  config:
    webhook:
      ALLOWED_HOST_LIST: "external, 172.30.0.0/16"
```

`172.30.0.0/16` is this cluster's `serviceNetwork` (confirmed via `network.config/cluster`), which is what `pipelines-as-code-controller.openshift-pipelines.svc.cluster.local` resolves to.

Deliberate choices:

- **`external` kept first** — this *widens* the list, it does not replace it. Outbound webhooks to real internet hosts behave exactly as before.
- **Service CIDR, not `private`** — the broader category would also permit `192.168.0.0/16`, letting a compromised repo aim a webhook at the LAN. The service CIDR is the smallest range that solves the problem.
- Forgejo and the PaC controller are in the **same cluster**, so forgejo-hosted repos should target the internal Service (`…svc.cluster.local:8080`, plain HTTP → targetPort 8082; the route is edge-terminated) rather than hairpinning through the public ingress. Repo webhooks are switched separately — they are set via the Forgejo API, not managed here.
- **Codeberg-hosted repos are unaffected.** They reach PaC from outside via the route and never consult this setting. 17 of the 18 PaC `Repository` CRs are Codeberg-backed; only `feeldata-dev/forgejo-feeldata-app` is on Forgejo today.

## Blast radius / rollout

Applying this changes the config Secret, which **rolls the Forgejo pod** — expect a short forge outage on sync.

Blocks `Systems-g1r`: every repo migrated from Codeberg to Forgejo hits this same wall on arrival, so this is a prerequisite for that migration rather than a one-repo fix.

Syntax verified against the Forgejo config cheat-sheet: `ALLOWED_HOST_LIST` accepts builtin categories (`loopback`, `private`, `external`), CIDR ranges and wildcard host patterns, comma-separated. Values file re-parsed after editing; `gitea.config` siblings and all top-level keys intact.

Refs `Systems-nd4b`.