### PR TITLE
feat: ✨ CI-gated Renovate automerge for feeldata on Forgejo

### DIFF
--- a/manifests/applications/b4mad-renovate/config-forgejo.yaml
+++ b/manifests/applications/b4mad-renovate/config-forgejo.yaml
@@ -49,4 +49,35 @@ data:
           // 2025-01-05 until it was closed). Widen only on purpose.
           "feeldata/feeldata2.app"
         ],
+        "packageRules": [
+          {
+            // Unattended merging for feeldata, gated by CI. `platformAutomerge`
+            // above hands the merge to Forgejo at PR-creation time, so the ONLY
+            // thing standing between a bad bump and `main` is branch
+            // protection: feeldata2.app `main` requires the status check glob
+            // `op1st Pipelines as Code / *`. Without that rule Forgejo merges
+            // immediately, before Pipelines-as-Code has posted anything.
+            //
+            // ⚠️ Do not enable this for a repo that has no equivalent required
+            // check. Verify with:
+            //   GET /api/v1/repos/<owner>/<repo>/branch_protections
+            // (the forgejo-mcp `list_branch_protections` tool has been seen
+            // returning an empty list for a repo that does have a rule — trust
+            // the raw API, not the tool.)
+            //
+            // Majors are excluded on purpose: a green pipeline is much weaker
+            // evidence of safety for a breaking change than for a patch.
+            "matchRepositories": [
+              "feeldata/**"
+            ],
+            "matchUpdateTypes": [
+              "minor",
+              "patch",
+              "digest",
+              "pin",
+              "lockFileMaintenance"
+            ],
+            "automerge": true
+          }
+        ],
     };


### PR DESCRIPTION
Adds a `packageRule` to the Forgejo Renovate fleet that automerges **minor, patch, digest, pin and lockFileMaintenance** updates for `feeldata/**`. Majors stay manual.

### Why this wasn't already working

`platformAutomerge: true` was already set fleet-wide, but that only controls *how* Renovate merges — nothing ever set `automerge`, so no PR could merge unattended.

### Where the CI gate actually lives

Because `platformAutomerge` hands the merge to Forgejo at **PR-creation time**, Renovate's own "wait for green" check is bypassed. The only thing between a bad bump and `main` is branch protection.

Already applied out-of-band on `feeldata/feeldata2.app`:

- required status check glob `op1st Pipelines as Code / *`

The pre-existing rule listed the bare prefix `op1st Pipelines as Code`, which matches **no** context Pipelines-as-Code actually posts (real contexts look like `op1st Pipelines as Code / web-build`) — it would have blocked every PR forever.

⚠️ Do not copy this `packageRule` to another repo without confirming that repo has an equivalent required check. Without one, Forgejo auto-merge fires immediately, before PaC posts anything.

### Scope

`autodiscoverFilter` limits feeldata to exactly `feeldata/feeldata2.app`, so `feeldata/**` is effectively that one repo today.

### Known gap

3 of 9 open Renovate PRs (#68, #62, #61) post *zero* CI statuses and therefore can never satisfy the glob. They sit unmerged — the safe outcome, but a silent one. Tracked as `Systems-4m9j`; related to but distinct from `Systems-pdnc`.

### Validation

- ConfigMap parses as YAML; embedded `config.js` evaluates in Node with the expected `packageRules`
- `matchRepositories` confirmed present in Renovate's *global* config schema, so it is legal in `config.js`
- Forgejo 16.0.1 ≥ v10.0.0, the minimum for platform-native automerge