### PR TITLE
fix: 🐛 a comment broke the realm import; guard against it

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,15 @@ repos:
         entry: scripts/check-sops-encrypted.sh
         language: script
         files: '\.enc\.ya?ml$'
+
+# keycloak-config-cli substitutes over raw file text before parsing YAML, so a
+# substitution reference written in a comment is resolved like a real one and
+# aborts the import. Valid YAML, passes kustomize build, fails only against the
+# live server — exactly the class of bug worth catching mechanically.
+-   repo: local
+    hooks:
+    -   id: realm-config-substitution
+        name: No substitution variables in realm-config comments
+        entry: scripts/check-realm-config-substitution.sh
+        language: script
+        files: 'realm-config/.*\.ya?ml$'

--- a/manifests/applications/b4mad-keycloak/realm-config/b4mad-forgejo.yaml
+++ b/manifests/applications/b4mad-keycloak/realm-config/b4mad-forgejo.yaml
@@ -14,10 +14,17 @@
 # realm needs from erdgeschoss — a broker client — is still provisioned by
 # setup-erdgeschoss-broker-job.yaml.
 #
-# Secrets are `$(env:…)` references resolved at import time from the Secret
+# Secrets are env-variable references resolved at import time from the Secret
 # b4mad-forgejo-realm-secrets (see README.md). Nothing sensitive is in git,
 # and IMPORT_VARSUBSTITUTION_UNDEFINEDISERROR (default true) makes a missing
 # value fail the sync loudly rather than importing an empty secret.
+#
+# ⚠️ Do NOT write a substitution reference in a comment, not even as an
+# example. keycloak-config-cli substitutes over the RAW FILE TEXT before any
+# YAML is parsed, so it cannot tell a comment from a value: a prose mention
+# is resolved like a real reference and aborts the whole import with
+# "Cannot resolve variable". This exact line once read "$" + "(env:…)" and
+# broke the first live sync. Name variables in prose without the sigil.
 realm: b4mad-forgejo
 id: b4mad-forgejo
 displayName: "#B4mad Forge - a Tier-2 forge"

--- a/scripts/check-realm-config-substitution.sh
+++ b/scripts/check-realm-config-substitution.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Refuse to commit a keycloak-config-cli realm file that names a substitution
+# variable inside a comment.
+#
+# keycloak-config-cli runs its StringSubstitutor over the RAW FILE TEXT before
+# the YAML is parsed, so it has no concept of a comment. A reference written
+# as documentation — even an obviously illustrative one with an ellipsis — is
+# resolved exactly like a real value, and an unresolvable name aborts the
+# whole import with "Cannot resolve variable" (because
+# IMPORT_VARSUBSTITUTION_UNDEFINEDISERROR defaults to true).
+#
+# That is a nasty failure mode: the file is valid YAML, it renders fine under
+# `kustomize build`, and nothing catches it until the PostSync hook fails
+# against the live server. It happened on the first sync of realm
+# b4mad-forgejo, from a comment reading "$" "(env:…)".
+#
+# Real references belong on value lines only. This hook enforces that.
+set -euo pipefail
+
+rc=0
+for f in "$@"; do
+  [ -f "$f" ] || continue
+  # Comment lines only: optional leading whitespace, then '#'.
+  while IFS=: read -r lineno text; do
+    [ -n "${lineno:-}" ] || continue
+    echo "ERROR: $f:$lineno names a substitution variable in a comment." >&2
+    echo "       ${text#"${text%%[![:space:]]*}"}" >&2
+    rc=1
+  done < <(grep -nE '^[[:space:]]*#.*\$\(' "$f" || true)
+done
+
+if [ "$rc" -ne 0 ]; then
+  echo >&2
+  echo "keycloak-config-cli substitutes over raw file text, before YAML is" >&2
+  echo "parsed — it cannot tell a comment from a value. A prose mention is" >&2
+  echo "resolved like a real reference and fails the import." >&2
+  echo "Describe the variable by name, without the substitution sigil." >&2
+fi
+exit "$rc"


### PR DESCRIPTION
Follow-up to #122, which merged green but whose PostSync hook failed on the
first live sync. Realm `b4mad-forgejo` was never created.

## Cause

keycloak-config-cli runs its `StringSubstitutor` over the **raw file text
before any YAML is parsed**, so it cannot tell a comment from a value. The
header comment in `realm-config/b4mad-forgejo.yaml` documented the secret
convention using a literal substitution reference with an ellipsis. The
substitutor treated it as a real variable:

```
Cannot resolve variable 'env:…' (enableSubstitutionInVariables=true).
  at KeycloakImportProvider.substituteImportResource(KeycloakImportProvider.java:209)
```

`IMPORT_VARSUBSTITUTION_UNDEFINEDISERROR` defaults to true — deliberately, so
a missing secret fails loudly rather than importing an empty one — so this
aborted the entire import. The Job hit `BackoffLimitExceeded` and the Argo
operation stayed `Running`.

Ironically, the failing line was the comment explaining that mechanism.

## Why nothing caught it

The file is valid YAML. `kustomize build` renders it. Both existing
pre-commit hooks pass. Both required CI checks passed on #122. It fails
**only** against a live server, at PostSync, after merge.

That is worth a mechanical guard rather than a comment asking people to
remember. This adds `scripts/check-realm-config-substitution.sh`, which
rejects any substitution sigil inside a comment in `realm-config/` — the
whole class, not this instance. Tested both directions: it flags the
original line and passes the corrected file.

## Verified against live Keycloak

Ran the fixed config through a standalone copy of the Job before committing:

```
Importing file 'file:/config/b4mad-forgejo.yaml'
Server info available. Using version: 26.4.7
keycloak-config-cli ran in 00:08.425.
```

Realm now exists with the `forgejo-admins` group, both identity providers
(`erdgeschoss`, `codeberg`), the `forgejo` client with its exact redirect
URI, and the `oidc-advanced-group-idp-mapper`. Debug pod and temp ConfigMap
were removed afterwards.

⚠️ Still outstanding from #122: the Codeberg client secret should be rotated
and resealed.