### PR TITLE
feat: ✨ cut Forgejo SSO over to realm b4mad-forgejo

### DIFF
--- a/manifests/applications/b4mad-forgejo/README.md
+++ b/manifests/applications/b4mad-forgejo/README.md
@@ -136,11 +136,34 @@ cluster.
 
 ## Auth (SSO-only)
 
-- OIDC login source `b4mad` against Keycloak realm **b4mad.industries**
-  (`https://keycloak.erdgeschoss.b4mad.net/realms/b4mad.industries`).
+- OIDC login source `b4mad` against Keycloak realm **b4mad-forgejo**
+  (`https://keycloak.erdgeschoss.b4mad.net/realms/b4mad-forgejo`). Cut over
+  from realm `b4mad.industries` on 2026-07-29.
+- That realm holds **no local identities**. It brokers to erd/G/eschoss (which
+  grants site-admin, via `/admins` → `forgejo-admins`) and to Codeberg (which
+  does not). See `b4mad-keycloak/README.md`.
 - First SSO login **auto-provisions** an account
   (`ENABLE_AUTO_REGISTRATION`, username from `preferred_username`, linked by
   email).
+
+### ⚠️ The realm cutover re-links accounts by email
+
+Forgejo keys an OAuth account by login source + `login_name`, which stores the
+`sub` claim. `sub` is **realm-scoped**, so changing realm invalidates the
+stored value for every pre-existing SSO account — at the time of the cutover,
+just `goern` (sub `81527376-…`).
+
+Nothing breaks only because `ACCOUNT_LINKING = auto` re-links an incoming
+identity to an existing account with the same email, rewriting `login_name`.
+Setting `ACCOUNT_LINKING: disabled` would instead strand every existing SSO
+account behind a login that can never match.
+
+⚠️ The same mechanism is a takeover path now that a **public** provider
+(Codeberg) is enabled with `trustEmail: true`: anyone who can present a
+verified address matching an existing Forgejo user's email auto-links to that
+account. Today every such address is `@b4mad.net`, a domain we control, which
+is what keeps this bounded — it stops being bounded the moment a user with an
+address on a third-party domain exists.
 - Local username/password sign-in is **disabled** (`ENABLE_INTERNAL_SIGNIN:
   false`). Only the Keycloak button appears.
 - ⚠️ This also disables web login for the built-in `gitea_admin` account —

--- a/manifests/applications/b4mad-forgejo/values-nostromo.yaml
+++ b/manifests/applications/b4mad-forgejo/values-nostromo.yaml
@@ -69,7 +69,19 @@ gitea:
     - name: 'b4mad'
       provider: openidConnect
       existingSecret: forgejo-oauth-secret
-      autoDiscoverUrl: https://keycloak.erdgeschoss.b4mad.net/realms/b4mad.industries/.well-known/openid-configuration
+      # ⚠️ Cut over from realm b4mad.industries on 2026-07-29. The client
+      # secret is deliberately identical in both realms (b4mad-forgejo reuses
+      # the one issued in b4mad.industries), so this needed no reseal of
+      # forgejo-oauth-secret — verified equal by digest before the switch.
+      #
+      # ⚠️ Forgejo keys an OAuth account by login_source + login_name, where
+      # login_name holds the `sub` claim. `sub` is realm-scoped, so every
+      # pre-existing account's stored sub is now stale. Re-linking relies
+      # entirely on ACCOUNT_LINKING=auto below, which matches on email — user
+      # `goern` carried sub 81527376-… from the old realm and will be relinked
+      # on first login. If ACCOUNT_LINKING is ever set to `disabled`, this
+      # cutover strands every existing SSO account instead.
+      autoDiscoverUrl: https://keycloak.erdgeschoss.b4mad.net/realms/b4mad-forgejo/.well-known/openid-configuration
       # Request email/profile so auto-created accounts get email + username
       # populated. Forgejo always prepends 'openid', so don't list it here.
       scopes: 'email profile'


### PR DESCRIPTION
Points the `b4mad` OIDC login source at the realm added in #122 (fixed in
#123) instead of `b4mad.industries`. This is the change that makes that realm
actually used — until now it was live and correct but nothing consumed it.

Argo auto-syncs this app with `selfHeal` and `prune`, so **merging rolls it
out**. Login behaviour changes at that moment.

## Verified before switching

- The `forgejo` client secret is **byte-identical in both realms** — compared
  by SHA-256 against the live `forgejo-oauth-secret` (`55d89e5f352ba3d1`, both
  32 chars). No reseal required, which was the whole point of reusing the
  existing secret when the realm was created.
- Client id is `forgejo` in both.
- The new realm's discovery document serves the expected issuer and endpoints.
- `helm template` against forgejo-helm 17.1.3 renders the new URL, with **no
  remaining reference** to the old realm. (Note `kustomize build` does *not*
  validate this file — the chart is a second Argo source consuming it via
  `$values`.)

## ⚠️ The subtle part: `sub` is realm-scoped

Forgejo keys an OAuth account by login source + `login_name`, and `login_name`
stores the `sub` claim. Changing realm invalidates that value for **every**
pre-existing SSO account.

Today that is exactly one account — `goern`, `sub 81527376-…`, `is_admin`.
(`external_login_user` is empty; the linkage lives in `user.login_name`.)

Nothing breaks only because `ACCOUNT_LINKING = auto` re-links an incoming
identity to an existing account **by email**, rewriting `login_name` on first
login. That setting is what makes this a safe change rather than a lockout,
so the risk is now documented directly next to it — setting it to `disabled`
would strand every existing SSO account behind a login that can never match.

`gitea_admin` is local (`login_type` 0) and unaffected; it remains break-glass
via `oc exec … gitea admin`.

## ⚠️ Second-order consequence worth a conscious decision

Email-based auto-linking now combines with a **public** identity provider
(Codeberg, `trustEmail: true`). Anyone presenting a verified address matching
an existing Forgejo user's email auto-links to that account.

Bounded today only because every email on the instance is `@b4mad.net`, a
domain we control. It stops being bounded the moment a user with a
third-party address exists. Documented in the app README rather than left
implicit.

## Post-merge check

First SSO login should land on the existing `goern` account with admin
retained, not a new one. Confirm with:

```sql
select id,name,is_admin,login_name from "user" where name='goern';
```

`login_name` should have changed to the new realm's `sub`.