### PR TITLE
feat: ✨ skip the login interstitial, go straight to Keycloak

### DIFF
--- a/manifests/applications/b4mad-forgejo/forgejo-home-template.configmap.yaml
+++ b/manifests/applications/b4mad-forgejo/forgejo-home-template.configmap.yaml
@@ -9,6 +9,12 @@
 # default forgejo-auto theme under prefers-color-scheme: dark). Light mode
 # keeps Forgejo's defaults. Only the home hero is styled, not Forgejo's chrome.
 #
+# ⚠️ The Sign-in buttons link straight to /user/oauth2/b4mad (Forgejo's
+# "start OIDC flow" route) instead of /user/login, skipping the interstitial
+# login page — internal signin is off, so that page only ever showed this one
+# button. `b4mad` MUST stay in sync with gitea.oauth[0].name in
+# values-nostromo.yaml; rename the login source and these links 404.
+#
 # To change the page: edit the home.tmpl content below, re-apply this
 # ConfigMap, and bounce the pod (subPath configmap mounts don't hot-reload):
 #   oc -n b4mad-forgejo apply -f forgejo-home-template.configmap.yaml
@@ -189,7 +195,7 @@ data:
         {{if not .IsSigned}}
           {{/* ---- Shown ONLY to logged-out visitors ---- */}}
           <p>Sign in with your b4mad.net account to continue.</p>
-          <a class="ui primary button b4mad-btn" href="{{AppSubUrl}}/user/login">Sign in</a>
+          <a class="ui primary button b4mad-btn" href="{{AppSubUrl}}/user/oauth2/b4mad">Sign in</a>
         {{end}}
       </div>
 
@@ -267,7 +273,7 @@ data:
 
         <section class="sv-cta">
           <p>Agents work here. The vault just holds.</p>
-          <a class="ui primary button b4mad-btn" href="{{AppSubUrl}}/user/login">Sign in with b4mad.net</a>
+          <a class="ui primary button b4mad-btn" href="{{AppSubUrl}}/user/oauth2/b4mad">Sign in with b4mad.net</a>
         </section>
 
       </div>


### PR DESCRIPTION
The landing page's Sign-in buttons now link to `/user/oauth2/b4mad` — Forgejo's "start the OIDC flow" route — instead of `/user/login`. With `ENABLE_INTERNAL_SIGNIN: false` that page only ever rendered this single SSO button, so it was a pure extra click.

**Not a full bypass:** Forgejo's own navbar Sign In button and any auth-required redirect still land on `/user/login`. Removing that entirely would need a `user/auth/signin.tmpl` override too.

**New coupling:** the `b4mad` slug in the href must match `gitea.oauth[0].name` in `values-nostromo.yaml`. Noted in the ConfigMap header.

**Post-merge:** subPath ConfigMap mounts don't hot-reload — needs `oc -n b4mad-forgejo rollout restart deploy/forgejo` after Argo syncs.