### PR TITLE
chore: 🔧 move forgejo-mcp from the Codeberg to the Forgejo Renovate fleet

### DIFF
--- a/manifests/applications/b4mad-renovate/config-forgejo.yaml
+++ b/manifests/applications/b4mad-renovate/config-forgejo.yaml
@@ -41,6 +41,11 @@ data:
         "autodiscoverFilter": [
           "toolbxs/*",
           "b4mad/*",
+          // Deliberately ONE repo, not `agentic-forges/*`. forgejo-mcp moved
+          // off codeberg.org on 2026-07-29 and was dropped from the Codeberg
+          // fleet in the same change; forge-agents is not yet onboarded.
+          // Widen only on purpose.
+          "agentic-forges/forgejo-mcp",
           // Deliberately ONE repo, not `feeldata/*`. The org migrated off
           // codeberg.org on 2026-07-28 with four repos, but only feeldata2.app
           // is to be renovated: feeldata.app is the superseded site,

--- a/manifests/applications/b4mad-renovate/config.yaml
+++ b/manifests/applications/b4mad-renovate/config.yaml
@@ -39,12 +39,16 @@ data:
           // token returns nothing, so this is a deleted/renamed repo rather
           // than a permissions or rate-limit symptom.
           "goern/epaper-service",
-          "goern/forgejo-mcp",
           "goern/hausmeister",
           "goern/sops2sealedsecret"
           // machdenstaat/* removed 2026-07-28: renovate disabled for the whole
           // org on operator request. Was lage, oparl-lite-2, stadt-bonn-oparl.
           // These repos now receive NO dependency updates until re-enrolled.
+          // goern/forgejo-mcp removed 2026-07-29: migrated to
+          // forgejo.b4mad.net/agentic-forges/forgejo-mcp. Codeberg is now a
+          // push-mirror downstream and renovating a mirror fights the
+          // mirror-push. Re-enrolled on the Forgejo fleet in the same change,
+          // so this repo keeps receiving updates — see config-forgejo.yaml.
           // toolbxs/* removed 2026-07-28: forgejo.b4mad.net is primary for that
           // org and codeberg is a push-mirror downstream. Renovating the mirror
           // would fight the mirror-push. Re-enrol against the Forgejo endpoint.


### PR DESCRIPTION
Migrated `goern/forgejo-mcp` -> `agentic-forges/forgejo-mcp` on forgejo.b4mad.net (2026-07-29). Codeberg is now a push-mirror downstream; renovating a mirror fights the mirror-push — same reasoning that dropped `toolbxs/*`.

- `config.yaml` — drop `goern/forgejo-mcp` from the Codeberg fleet
- `config-forgejo.yaml` — enrol `agentic-forges/forgejo-mcp` on the Forgejo fleet, so the repo does not fall into the "receives NO dependency updates" gap

Both ConfigMaps validated: embedded `config.js` parses under node and yields the expected arrays.

Refs Systems-ao3u.