### PR TITLE
feat: add forgejo-b4mad PaC secret for git.b4mad.industries

### DIFF
--- a/manifests/applications/op1st-pipelines-tokens/README.md
+++ b/manifests/applications/op1st-pipelines-tokens/README.md
@@ -12,7 +12,8 @@ and are fanned out to consumer namespaces by emberstack/reflector.
 | `codeberg-pusher` | `kubernetes.io/dockerconfigjson` | Codeberg container-registry push credentials. | `op1st-pipelines` |
 | `cosign-signing-key` | `Opaque` | Password-less Cosign signing key for forgejo-mcp release **artifact** signing. Keys: `cosign.key`, `cosign.password` (empty), `cosign.pub`. Locally generated via `cosign generate-key-pair` with `COSIGN_PASSWORD=""`. Public key also published as plain file `cosign-signing-key.pub` in this directory for verifier consumption via raw URL. | `op1st-pipelines` |
 | `cosign-signing-key-images` | `Opaque` | Password-less Cosign signing key for the release-tools **container image** signing. Same key layout as `cosign-signing-key`; kept distinct so a compromised release-tools image cannot forge signatures on artifact releases. Public key published as plain file `cosign-signing-key-images.pub`. | `op1st-pipelines` |
-| `forgejo-pusher` | `kubernetes.io/dockerconfigjson` | forgejo.b4mad.net container-registry push credentials, identity `b4mad-release-bot`. Consumed by the `push-to-forgejo` skopeo-copy task in toolbxs `on-tag` pipelines, and by the `push-forgejo` task of the `borg-build` pipeline in `b4mad-forgejo`. ⚠️ The bot must stay a member of the target org — an org-namespace package push without membership fails as a bare `authentication required`. | `op1st-pipelines`, `b4mad-forgejo` |
+| `forgejo-b4mad` | `Opaque` | PaC API token + webhook secret for `git.b4mad.industries`, identity `b4mad-gitops`. Keys: `provider.token`, `webhook.secret`. The webhook secret matches the **`agentic-forges` org hook** (id 2). Referenced by the `forgejo-b4mad-agentic-forges-forgejo-mcp` `Repository` CR. Note `feeldata-dev` keeps its own same-named secret, sealed in the feeldata manifests repo — deliberately not reflected here, so the two do not fight. | `op1st-pipelines` |
+| `forgejo-pusher` | `kubernetes.io/dockerconfigjson` | git.b4mad.industries container-registry push credentials, identity `b4mad-release-agent` (renamed from `b4mad-release-bot` 2026-07-30 — the username inside the dockerconfigjson is cosmetic, the forge resolves identity from the PAT alone). Consumed by the `push-to-forgejo` skopeo-copy task in toolbxs `on-tag` pipelines, by the `push-forgejo` task of the `borg-build` pipeline in `b4mad-forgejo`, and by the forgejo-mcp release pipeline. ⚠️ The agent must stay a member of the target org — an org-namespace package push without membership fails as a bare `authentication required`. | `op1st-pipelines`, `b4mad-forgejo` |
 | `op1st-release-token` | `Opaque` | Release credentials. Keys: `username`, `token`. | `op1st-pipelines` |
 
 Add new tokens here as they appear.
@@ -104,6 +105,20 @@ sops codeberg-pusher.enc.yaml
 git add codeberg-pusher.{enc.,}yaml
 git commit -m "chore(secrets): reseal codeberg-pusher for op1st-gitops"
 ```
+
+> ⚠️ **`reseal` rewrites every `*.enc.yaml` in the directory, not just yours.**
+> Two consequences, both observed on 2026-07-30:
+>
+> 1. kubeseal re-randomizes ciphertext on every run, so all nine tracked
+>    `*.yaml` show a diff even when nothing changed. Stage only the files you
+>    actually meant to touch.
+> 2. Any `*.enc.yaml` that omits `metadata.namespace` gets sealed for
+>    namespace `default` instead of `op1st-gitops`. SealedSecrets are
+>    namespace-scoped, so such a file **will not decrypt** once applied. This
+>    currently affects `arena-forge-forgejo-read`, `arena-forge-forgejo-write`
+>    and `arena-forge-pipeline-agent`. Always diff for a
+>    `namespace: op1st-gitops` -> `namespace: default` flip before committing,
+>    and add an explicit `metadata.namespace` to any plaintext that lacks one.
 
 ## Consumer migration
 

--- a/manifests/applications/op1st-pipelines-tokens/forgejo-b4mad.enc.yaml
+++ b/manifests/applications/op1st-pipelines-tokens/forgejo-b4mad.enc.yaml
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: forgejo-b4mad
+    namespace: op1st-gitops
+    annotations:
+        b4mad.net/href: https://git.b4mad.industries/b4mad-gitops
+        reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+        reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: op1st-pipelines
+        reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+        reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: op1st-pipelines
+type: Opaque
+stringData:
+    provider.token: ENC[AES256_GCM,data:yAgQ+zf+PssoXy3pu/f+B6PPMoVUlfcryo2u0OA3RhfAgAON1xKicQ==,iv:m6Dn48R/oNdjSk28gWcuzGZnDdkcZeExgkijF88BCDQ=,tag:V1UnzJPwQeUe3M6xZN88ZA==,type:str]
+    webhook.secret: ENC[AES256_GCM,data:ijKb860UItQpnKRXkoMDp+8S/ISkDsQ8JYxWtGH3kY7ecxFxMU8OL/hI9Emx21MEozHGfFJDC/RnjTkRslcAtA==,iv:5/1S1EMrMiYcZTDIRI+vIB7qF92WDyeSYt4nvUZPBPU=,tag:L2MGw5S7ERxb5hZK9aH0rw==,type:str]
+data: {}
+sops:
+    lastmodified: "2026-07-30T11:22:18Z"
+    mac: ENC[AES256_GCM,data:z41ISfrXIsmEV+4RApulxpOwviVtRwjZ5dgPGt4QlDCiFuLIQg2GLYjE48O84o5Je5PeLg3vUAKSjR/utYYfFn++HqnK7LHuLyykpW0IX8kyyuecpRLmqcX77MhtPpQga7Co5lx/B0nWxSQEYkuiDIVRzG98cyeXHx1FRPcbf+c=,iv:qOI9qeA6tPxtuPrDL+VE2+sciORY1cI3G4OJJE+00h4=,tag:2jADQXBzpNu4nk+KZ200lw==,type:str]
+    pgp:
+        - created_at: "2026-07-30T11:22:18Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA9AgVmznaOk7AQ/9EyzH5OKzsxBvwHcbgozHKWHTi5RAFlp9FmHXQR3W+XtX
+            WxsWMHx5lIrV+zRJZHXnbUQhKiJ17JL1Ik6v8p1iRh5XABD2fQhzjfSuUBEL2bKu
+            xtGL+aWCzC+HM1Fmowt34kQAhdCfOcqmBF3wwxikPQd/UPru1S993dgET2CTxWfz
+            aDaJD0lhw/1toFm7UJUQp45jHrWGZKvU2IBa1y9hHHqGIvHuWfVqbpVmptNagS8q
+            bYazZE43otd+qprQbMzUrrpR5J6iTnKjRaNSjisIJmrGt6XFenuf75HOayZMRmdI
+            x/NVfylKx7IdWQIH+mHjVhzwVcYI8WJAT1Jv1ZUrcrddJCetk0ga3UAeiRuAU2Yq
+            9io+ME03PCUX5SVcvrl0wlm4R2u6xG3gf9uVSW7YqqmOpCNm7H+59WxHifDJalci
+            aeT78k2XobVd9dGCqnrYSZ8BDA4sopOvglhdmcOq8R32he/cZG/ix6yJzHZyf52A
+            yO/rVOIUq0m5bEq5mXKXj4UsylI00suEXBy++A8cxXbtWI4ZHSs+/60q1wI6IF+D
+            ZuiMUBQajgflve48fRw1Vql+U4iS+/acCKt23Z2HVGPwyKOG7tifaizv89QpvHBb
+            klSwmbb0PWKcZTjHg/fhur0nyU07ADbWYeR6beVSqM3APIk9jT39onmQWZ1k/7/S
+            XAHFY9OLg+BjZlX9GuN2/VWpb8VlJ7u2h99EjsuBXtKtCX/fimD3sDDkFrvnylJK
+            zCWpOyAQI92ZPV1kqKgji4LsSeYBb8sKR2kjkdMmnr8dr95zmBLyJln1CsFK
+            =OML1
+            -----END PGP MESSAGE-----
+          fp: 04DAFCD9470A962A2F272984E5EB0DA32F3372AC
+        - created_at: "2026-07-30T11:22:18Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMAwSHi8yuDIZWAQ//Xg7qdmIK2V4/iW8azZqvqTRKCStxnsBtnunyQ1fryUkm
+            PRgHVG1f4Nc3hmZLi7zGv6R4+dzevdvpnz0zLileOeGf8ET7vPL5u3oxm4oZM3e+
+            3Eb55cgQ+hN1I1tZTyqNv4CWugOpANV9QDqIhy017nFk5Led8sBxfsp8SbULrFaD
+            cd0QbmZNyFASJIW3C3u66cfcCCQzscTywXQpd4A9dl7EjiX5uMZRzkSWGc3rT6UL
+            8oEl2I1AF8T/J/bSTWmhTB7BqvEL+8w2yq1PyvKy70ZkxfPX4IiJzs/8LO5KfpEW
+            6vYWarjXsqk/7tcFNdUUBvS9UgJ2sZFJt9mTURZ1GRv4e0TBcb4dGDDjs8zdODMV
+            Xqa6lzb0styUnd+b1SymgHH4TnTj2enKxW5bNs3rnurIoKEoGVvW5x1NaHb47Ib4
+            p1Cbkie6dbHQLQyIR5aKq19tdnSGL81mo4hYicyMrSij9Bwl3z7YWcrt6SexgccI
+            oaiqAvcSwWLnHa2fBsQirfT6hDFgbkSBd8Ps+BSnE02mI17zJbgOrS/2LBCPo0gb
+            hNey+Rn2XG/KF1r/Jv77Qz+K7Ht73jZD5hwW2N0zzd/HWPBGKmKWbUmbtOohUGHS
+            SVeTVnaW2t9hLzMP5ujQjyf9qoFcyN+0+pGsbVx1IjhZgtuGc2AbAtHs1QVbGTXS
+            XAFcJtizfGpI9L9T2Y6Rz03PLV5uw+4FUALuGwIvFiE4KBS+Q7RtnUe3sCE2ESi+
+            IzKxuwXW6WtYcSMVukAl6e3PFWHbX4X9KYPcKcVKs15W90zbfCo0Z8UY4Ptm
+            =bvUT
+            -----END PGP MESSAGE-----
+          fp: 8A07D816280A983BBC35E85C280DB66A3E8C012E
+    encrypted_regex: ^(data|stringData|tls)$
+    version: 3.12.1

--- a/manifests/applications/op1st-pipelines-tokens/forgejo-b4mad.yaml
+++ b/manifests/applications/op1st-pipelines-tokens/forgejo-b4mad.yaml
@@ -1,0 +1,22 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: forgejo-b4mad
+  namespace: op1st-gitops
+spec:
+  encryptedData:
+    provider.token: AgDCZP8ZGv3ybC+I7fy/eVzd6OphfQ5pNuJfX9aoeBOd51DnTdNu8a6PevloXtnyr3xNyzRw/IcrjfoDPE15eQhHjTYaxS7XKH8m41BJF8rmvE1kkeQgILpgEEleDmYt0H8draVvF/xbvNYCTjntojyDh93WLPhxNPjfHzL/NB6lsOqxfDf4MqBzh3CTmKQ6u+Qo0WnGSp/hkK0krZxbveZMX7mpAzK7mS5flZCDbdezKRyawB5g98jjFGFJBx9B41t8XyH0L0sow0d0PjTQ7sC4adWewlPRpUdzkhs/yGhwSZWj71clYQbVkq1LQUs3bSrWjUD0PA4gUe7wkp31vZZ4E2RBFYBg6+N3UffxI4xfq834NnMS1qgg3WpK9xLlLnxTOIxpYH6zxpRndj6Id6Qdm2G/h+t3HV4kF8XzToQTBj1G7C5+StvtcY+MMBehVeeiQcSOTtdAP+MD/LNDJKfiLn4igZAexDgl1IZCPJnncdPjzJnrq8xMHZWUMWsR5HGJGR4obpzkFCPpqKjO3+4DuDJKeGhShNDAUugqPN56XpiCl/D+fyJyecVLfpgEwtsI4TBLrIJCI2gdqL1DQZ78+AZtVHwYAEiOM8gFpDXyEpbzG6C7wKtCQRvthAAMLO94vtW5mDRT51Mh9pGzm7DTI/msnNsD1Q4r1vuJIxE3Y49SjyH6p/uVJwAd06MovY/CrT/sLhBgIcJW60NqtEezHM4j90kAsUMUiQMbqoPgwigSZvHBINEp
+    webhook.secret: AgBrLrT7ncyCGad9bCmXorW99xBknf/9d3yYDVFKeRAfhAr3/Z2eq3jmSZSJjrTBAPwCBPvpH5YW69Tbh8QgFsTGvvqiosMpMLYqVkGI5tGDKKbYEvr6iTXr4//P2YbwaNEzKLcGawNCpBM/+MAtgHRNrWaWkia7mPvY/LaaSwTOhm1e9lQdTPvlzmfkmqZUMOKcCzjKrhp1Xg9RTuzgq2lPZ9mQ6anLmTd88VJ5nrKh0v5Tj5hRACzlLYIknoqv2dd256RjeJ9gzpxVisH0IphokkCcW9sD8bSAFB2eMpS3zqTv7feis3BiIt/g3x3LPf8XGlnATagXTTK0P2HU12PN0i19KBpcJMKNvOMHMxQ65+r3FtEDdmDCkluWCXqEJQW85fOYOymecs1xlLuK80gdS4K1iiiiuSGIjq9mwX78dy3eM77KhV+26PnC9EakitHz35+d3Q12eYpyosflxYJzz2ts+7lw0nvu+dQLHTtB1wpJimZNMmWbwCgeARNqfOapBfN0+drBSXazGrK0tH79YU70N1UhQYd163YPLCQem7ZVneUxc04SS21B2m9mhl8K/n7NU7p1J7bGz00sSu9fwZaUAF2CuNKii/B0RwMzWTuApnP7mTKr1ZRcctEcRtOhI6P7hTb7coKEHE/PQRyqyjhvQIPo3wiT5anbs8kuXt9bOo3TWdQAlk5+AjV/pVen0/I2UmpnBGFPhYn0pWtS3G04rHVq6mCAxZ9IOA8jGJdyFfqy9AaVutC+CE8G6BDogngM3nQOuC2/laf/i3fw
+  template:
+    metadata:
+      annotations:
+        "b4mad.net/href": "https://git.b4mad.industries/b4mad-gitops"
+        "reflector.v1.k8s.emberstack.com/reflection-allowed": "true"
+        "reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces": "op1st-pipelines"
+        "reflector.v1.k8s.emberstack.com/reflection-auto-enabled": "true"
+        "reflector.v1.k8s.emberstack.com/reflection-auto-namespaces": "op1st-pipelines"
+      creationTimestamp: null
+      name: forgejo-b4mad
+      namespace: op1st-gitops
+    type: Opaque

--- a/manifests/applications/op1st-pipelines-tokens/kustomization.yaml
+++ b/manifests/applications/op1st-pipelines-tokens/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   - deploy-keys/codeberg-machdenstaat-oparl-lite-2-deploy-key.yaml
 
   - forgejo-pusher.yaml
+  - forgejo-b4mad.yaml
 
   - arena-forge-forgejo-read.yaml
   - arena-forge-forgejo-write.yaml


### PR DESCRIPTION
PaC needs provider + webhook credentials per forge instance. There were none for `git.b4mad.industries` in `op1st-gitops`, so the `Repository` CR for `agentic-forges/forgejo-mcp` could not be applied — **that repo's CI has been dead since the migration off Codeberg**:

```
warn  cannot find a repository match for https://git.b4mad.industries/agentic-forges/forgejo-mcp
      event-type push  provider gitea
```

Follows the `codeberg-pac-token` pattern: one canonical SealedSecret here, reflected into `op1st-pipelines`.

- **provider.token** — identity `b4mad-gitops`, which already holds admin on `agentic-forges/forgejo-mcp`.
- **webhook.secret** — freshly generated and set on the `agentic-forges` org hook (id 2) in the same change, so both sides match. Deliberately *not* reusing feeldata's value; their repo hook is separate and coupling them means one rotation breaks both teams.

`feeldata-dev` keeps its own same-named secret sealed in the feeldata manifests repo. This one reflects **only** into `op1st-pipelines`, so they never contend.

### Verified
- `kubeseal --validate` passes against the live controller
- `kustomize build` resolves `forgejo-b4mad` into `op1st-gitops`
- no plaintext in the diff

### ⚠️ Two `manage-secrets.sh reseal` footguns found (documented, not fixed here)
1. It re-randomizes **every** ciphertext in the directory — all nine tracked files show a diff even when unchanged. Stage selectively.
2. Any `*.enc.yaml` without `metadata.namespace` gets sealed for namespace `default`, producing a SealedSecret that **cannot decrypt**. `arena-forge-forgejo-{read,write}` and `arena-forge-pipeline-agent` are exposed to this. Left alone to keep this reviewable — worth a follow-up.

### After merge
```bash
oc apply -f .tekton/repository.yaml   # from the forgejo-mcp checkout
oc delete repository codeberg-org-goern-forgejo-mcp -n op1st-pipelines
```