### PR TITLE
feat: add b4mad-release-token for the forgejo-mcp release pipeline

### DIFF
--- a/manifests/applications/op1st-pipelines-tokens/README.md
+++ b/manifests/applications/op1st-pipelines-tokens/README.md
@@ -12,9 +12,10 @@ and are fanned out to consumer namespaces by emberstack/reflector.
 | `codeberg-pusher` | `kubernetes.io/dockerconfigjson` | Codeberg container-registry push credentials. | `op1st-pipelines` |
 | `cosign-signing-key` | `Opaque` | Password-less Cosign signing key for forgejo-mcp release **artifact** signing. Keys: `cosign.key`, `cosign.password` (empty), `cosign.pub`. Locally generated via `cosign generate-key-pair` with `COSIGN_PASSWORD=""`. Public key also published as plain file `cosign-signing-key.pub` in this directory for verifier consumption via raw URL. | `op1st-pipelines` |
 | `cosign-signing-key-images` | `Opaque` | Password-less Cosign signing key for the release-tools **container image** signing. Same key layout as `cosign-signing-key`; kept distinct so a compromised release-tools image cannot forge signatures on artifact releases. Public key published as plain file `cosign-signing-key-images.pub`. | `op1st-pipelines` |
-| `forgejo-b4mad` | `Opaque` | PaC API token + webhook secret for `git.b4mad.industries`, identity `b4mad-gitops`. Keys: `provider.token`, `webhook.secret`. The webhook secret matches the **`agentic-forges` org hook** (id 2) and the three `toolbxs` repo hooks (ids 3/4/5) — one value per forge instance, which is also the precondition for ever collapsing these into a single org hook. Referenced by the `forgejo-b4mad-agentic-forges-forgejo-mcp` and `forgejo-toolbxs-*` `Repository` CRs. ⚠️ PaC v0.42.2 enforces HMAC signature validation for the Forgejo provider, so every hook using this secret must carry exactly this value, and `b4mad-gitops` must stay a member of each consuming org with write permission — commit-status updates fail silently (`404`) otherwise. Note `feeldata-dev` keeps its own same-named secret, sealed in the feeldata manifests repo — deliberately not reflected here, so the two do not fight. | `op1st-pipelines` |
+| `forgejo-b4mad` | `Opaque` | PaC API token + webhook secret for `git.b4mad.industries`, identity `b4mad-gitops`. Keys: `provider.token`, `webhook.secret`. The webhook secret matches the **`agentic-forges` org hook** (id 6 — replaced id 2 on 2026-07-30, see below) and the three `toolbxs` repo hooks (ids 3/4/5) — one value per forge instance, which is also the precondition for ever collapsing these into a single org hook. Referenced by the `forgejo-b4mad-agentic-forges-forgejo-mcp` and `forgejo-toolbxs-*` `Repository` CRs. ⚠️ PaC v0.42.2 enforces HMAC signature validation for the Forgejo provider, so every hook using this secret must carry exactly this value, and `b4mad-gitops` must stay a member of each consuming org with write permission — commit-status updates fail silently (`404`) otherwise. Note `feeldata-dev` keeps its own same-named secret, sealed in the feeldata manifests repo — deliberately not reflected here, so the two do not fight. | `op1st-pipelines` |
 | `forgejo-pusher` | `kubernetes.io/dockerconfigjson` | git.b4mad.industries container-registry push credentials, identity `b4mad-release-agent` (renamed from `b4mad-release-bot` 2026-07-30 — the username inside the dockerconfigjson is cosmetic, the forge resolves identity from the PAT alone). Consumed by the `push-to-forgejo` skopeo-copy task in toolbxs `on-tag` pipelines, by the `push-forgejo` task of the `borg-build` pipeline in `b4mad-forgejo`, and by the forgejo-mcp release pipeline. ⚠️ The agent must stay a member of the target org — an org-namespace package push without membership fails as a bare `authentication required`. | `op1st-pipelines`, `b4mad-forgejo` |
-| `op1st-release-token` | `Opaque` | Release credentials. Keys: `username`, `token`. | `op1st-pipelines` |
+| `b4mad-release-token` | `Opaque` | Release credentials for `git.b4mad.industries`. Key: `token`. Consumed by the forgejo-mcp release pipeline — `goreleaser-release` (creates the release), `cosign-sign-release` and `mcpb-pack` (upload assets). Needs `write:repository` on `agentic-forges/forgejo-mcp`. ⚠️ Currently a **personal** PAT belonging to `goern` (user id 2), so automated releases are attributed to a human and the token carries repo admin — broader than the pipeline needs. Replacing it with a dedicated release identity is the tighter option. | `op1st-pipelines` |
+| `op1st-release-token` | `Opaque` | Codeberg release credentials. Keys: `username`, `token`. No longer referenced by forgejo-mcp (superseded by `b4mad-release-token` when that repo moved to git.b4mad.industries); retained for any other consumer. | `op1st-pipelines` |
 
 Add new tokens here as they appear.
 
@@ -105,6 +106,23 @@ sops codeberg-pusher.enc.yaml
 git add codeberg-pusher.{enc.,}yaml
 git commit -m "chore(secrets): reseal codeberg-pusher for op1st-gitops"
 ```
+
+## agentic-forges org webhook (2026-07-30)
+
+Hook id 2 was deleted and recreated as id 6. Two faults, both worth knowing
+before touching a hook again:
+
+1. It pointed at the PaC controller's **public route**, which the forge
+   refuses: `ALLOWED_HOST_LIST = external, 172.30.0.0/16`, and the route
+   resolves to `192.168.0.148` — a private LAN address that does not count as
+   `external`. Every delivery failed with *"webhook can only call allowed HTTP
+   servers"*. Use the in-cluster service URL
+   `http://pipelines-as-code-controller.openshift-pipelines.svc.cluster.local:8080`.
+2. Setting the secret via `PATCH /orgs/{org}/hooks/{id}` with `config.secret`
+   returns `200` but **does not store it** — deliveries then arrive unsigned
+   and PaC rejects them with *"gitea/forgejo webhook signature validation
+   failed"*. The API never echoes `secret` back, so this failure is invisible.
+   Supply the secret at **creation** time via `POST` instead.
 
 > ⚠️ **`reseal` rewrites every `*.enc.yaml` in the directory, not just yours.**
 > Two consequences, both observed on 2026-07-30:

--- a/manifests/applications/op1st-pipelines-tokens/b4mad-release-token.enc.yaml
+++ b/manifests/applications/op1st-pipelines-tokens/b4mad-release-token.enc.yaml
@@ -1,0 +1,61 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: b4mad-release-token
+    namespace: op1st-gitops
+    annotations:
+        b4mad.net/href: https://git.b4mad.industries/goern
+        reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+        reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: op1st-pipelines
+        reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+        reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: op1st-pipelines
+type: Opaque
+stringData:
+    token: ENC[AES256_GCM,data:x5pWYTHhG8s+Ok9s05dkulUOW/REv2DGlx9AMe2Bl6/lrtN3zJDBhg==,iv:Khn9pMOmx+R0Xsh+GvfK2nVO/XvHCq0Df2uA0ZXMq14=,tag:pfOTUEuVfZWV53GjIHI0Kg==,type:str]
+data: {}
+sops:
+    lastmodified: "2026-07-30T13:15:17Z"
+    mac: ENC[AES256_GCM,data:0QUob1ex3LbzPqDCWQGKfWdIQWtFFu3FL2h265V92h/KGB5lRQ640Tvo62Y7RT9YmLPxi7QKNqzjKgaRxd+PDWPS/gyIU0J/WQljAri2i52aeCui4rFo3tcxDvg1YPdWsUYhSZ1LHEBSNwFMDaA0DRTA+bgYtDNh91MGRBtcZgU=,iv:b2iJ5beJYaf8YVfc/HwDLNAAH1wVPPdQYY3SZT/HmTg=,tag:7IWh3MF76+JNsGbcFqXaDg==,type:str]
+    pgp:
+        - created_at: "2026-07-30T13:15:17Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMA9AgVmznaOk7ARAAjFp2fmrZzR/YC5Mc+q3ySwWUf1zZExBn3LeX62f39IPM
+            Rn8BhjmjdsTktCFQ99ihv3rZDaBXWWUV+Ydiy8JSPEScStis3QdSC9ju+/20HEN+
+            gFdtJceRX3WnNv0AWrEmliG3S6pD/4LlwqlmvLmyQ0WtraOSfm8E+jg4OGWLEbRh
+            S7RI6ViZj79srv5LQNn/hV5tTWCF5spomxEe+Dl74GlorIdTK4a/zYERJIeKZ9H4
+            /ndXV+WJawAJDp94Vmg6zxIL3ijepogYjC7KMK6QyD0U11BBq1vKVaRVwRfq7sxW
+            yyxEo93yQintM3bRYqTzBWkYzvgoEJrLSQjb//S/X/JTXi2cCRM/ivDb+jDO8gei
+            BX2Fyz6iZxclf6pwWINoubyhijQShKjm6W58Lxl7xIcmjgWnbU/3legSQ3s87wvl
+            xgdt8XWQPIJVdlhgcBrg2dv7744s5nbfowGRcLk/ieAvhI5U4TAg+uEenwyA/VJa
+            /a1LyPn3pU+d8VGa3H5DAXkPaO+9o6Jt7ERgXQc+weYRCDetEaF63l9QR1QPzue/
+            aWHRAwMkjUeuDgr1pn5//XcS4GJJxLME2tKAGlPPmUUpugiiIBBw5ogPE0bh409v
+            pAPdgx9rmAwWxy+NAVbWY5WCGvvbBcN/Fi9vjLLydTfdZW5qOzGiyZroXnguxHXS
+            XAFJXcEe3pryIxFYYup3lOMx02PGHRnksRv3iAeXpCZTCcZaN+FSKpW+5qFF1xPD
+            YZxPdYeRbeI9GAJU4oeISTJn5MVOhetdGpUIPyTSbkiZWICNkD3xiFgxeYIW
+            =IMsb
+            -----END PGP MESSAGE-----
+          fp: 04DAFCD9470A962A2F272984E5EB0DA32F3372AC
+        - created_at: "2026-07-30T13:15:17Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQIMAwSHi8yuDIZWAQ//cqwN8P+5iyq2Bnr6wXOkMsEN2EIYDtWgumRTEhBoA5V8
+            zpf5bKvhoz8J9hHMgQCwuUpyr1J2UV+H1FtrMUUSbslA6rgFl8yshisDFv5eW26T
+            CbrhRMyd9bCTfvS5dVc273pgykApt59Q74pX4tXVqz9RpGt8GwF0peqrwL55DmA0
+            +EiiABB7fnu2YYLoN4tppSm7vMHySOnAkOBxJl2rsTMm7HEKFevC1zfgw/nx686f
+            fGTXKPmMr1SpczJuStLhVOhcwz1CR0FtzicJ5fEm7Op8GYyZJXsXJlTYap8c5qtm
+            7hRrln0gm5IBwsVDRTMeVQVnzILyOjNvU3RHCjLFETlB8bh351d9AqQQY2LVqvOq
+            4H0E6roEB6bT6e6iu7aQTWGWfgDIj3lszIRqjJVKPHTK6InbQpPUE/0q0VAWbaSY
+            qiONcEt2XTRc2NrCBaqHPD6sijWYhTdW6v119AOg8kU6bvBV70w+YmdolCuQtq/l
+            NcFFhWE6gG7Bc7nO9iR9liz3dqsRhbNVj2h4mMDw2xNPpNFjKXMD+ZWL9SswwkYE
+            5/HYF2LXh7HSENF9f71SuaB5RKs383ucgPAfH0i3M1TeSrPXES9+LQR1CZRQ2k4N
+            hB8L6HQEatYipJlvmH8X880lNOqqH0GKGAzRUWsa5a/FfgveKj/DYVyvR1mACwfS
+            XAH0uLN41RdVQJCXsOvoPIz+coGBFwpASpdSlfv1HP5OyXh6V3wwY727h2SkZl0x
+            fjJA9b12agU6mP2bhp+DZWZZO/BceYraTzwSsv+BfTlh10XhFWCVQkK+L88X
+            =cZBq
+            -----END PGP MESSAGE-----
+          fp: 8A07D816280A983BBC35E85C280DB66A3E8C012E
+    encrypted_regex: ^(data|stringData|tls)$
+    version: 3.12.1

--- a/manifests/applications/op1st-pipelines-tokens/b4mad-release-token.yaml
+++ b/manifests/applications/op1st-pipelines-tokens/b4mad-release-token.yaml
@@ -1,0 +1,21 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: b4mad-release-token
+  namespace: op1st-gitops
+spec:
+  encryptedData:
+    token: AgC6pLmILouZVFu2qdhr79LUtJlK7oYt4wuxc3g0o+oIONh933fPo91k1nT1ncJgM9v0DWNv/7GFmvHduvXIvs2kz9fqKp3CVvSBvUMzgLm/O4IAGAqjC+HooULtMtF4BjOqOidaiTfhQnFtf5PuBBPvK9KPTN4EtJqM8cGwVssslulFI6/CU6SjVKBDMcpyIZo0JUsvtrGH5DaGEc9t3fA0Dqr7e636GM3uCPA04fA9VMkagORzEGDM5sgBN1dz/muycEaejhBHBTZm4VtIgmHB7F/aa9OX6TRcOukqIM/2k/YYBZmyFGONmdrAMgumAfksgKVlaZK06pe+/1qaKYiArh/UPsZAqySBE4dWynvsoTQA8n9etj35Ps55N8k5TbkrR9XTkzUvZC49nb1+l7kHbHh7SoEK9VyIIUZDkvbtXcDsWxJ0YSEvCtNNsAE8Fqgj6UxWl264bXhMdO0B2wc/jwRKNPfc272eqXFfVOxtPl8lRqTvu8AYakxniknDzw+zyZ/MeyocxtQLMdtt4Q6QkuR9jl2tRx0+zNCN1quLFQtTERykfrnGgvFff3sDtOGWdrcKgjlpZthVq1U7gnhKpv/pMnOWCL85nyg5dMlXskEZNyAR+/USP7bI6s3MvGjEm3uqDHVlMxLNyWBzDePAUOqmc7rGJc49ENrQOARBNDclk+1TVnNaJk0CMMB6Rcv5SpofyGUzcy2BX3wjIKF9AKZJrTmu3gBJzz+P2agNOvXROYU7lZYK
+  template:
+    metadata:
+      annotations:
+        "b4mad.net/href": "https://git.b4mad.industries/goern"
+        "reflector.v1.k8s.emberstack.com/reflection-allowed": "true"
+        "reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces": "op1st-pipelines"
+        "reflector.v1.k8s.emberstack.com/reflection-auto-enabled": "true"
+        "reflector.v1.k8s.emberstack.com/reflection-auto-namespaces": "op1st-pipelines"
+      creationTimestamp: null
+      name: b4mad-release-token
+      namespace: op1st-gitops
+    type: Opaque

--- a/manifests/applications/op1st-pipelines-tokens/kustomization.yaml
+++ b/manifests/applications/op1st-pipelines-tokens/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - cosign-signing-key-artifacts.yaml
   - cosign-signing-key-images.yaml
   - op1st-release-token.yaml
+  - b4mad-release-token.yaml
 
   - deploy-keys/codeberg-goern-epaper_service.yaml
   - deploy-keys/codeberg-goern-hausmeister-deploy-key.yaml


### PR DESCRIPTION
`goreleaser-release`, `cosign-sign-release` and `mcpb-pack` all reference `b4mad-release-token` after the forgejo-mcp release pipeline was repointed at `git.b4mad.industries` — but the secret did not exist. **The next `v*` tag would have failed at the first task** with `CreateContainerConfigError`, after the tag was already pushed to the forge.

Sealed here rather than hand-created in `op1st-pipelines`, so it survives a namespace rebuild like every other credential in this app.

### ⚠️ The PAT is personal
It belongs to `goern` (user id 2). Verified to carry `write:repository` and admin on `agentic-forges/forgejo-mcp`, so it works — but automated releases will be attributed to a human, and it grants more than the pipeline needs. A dedicated release identity would be tighter. Recorded in the README so it stays a visible choice.

### Also in here
- `op1st-release-token` row now says it is the **Codeberg** token and that forgejo-mcp no longer uses it
- corrects the `agentic-forges` org hook id: **2 -> 6**
- documents two webhook faults found while restoring forgejo-mcp CI:
  1. the forge refuses the PaC **public route** — `ALLOWED_HOST_LIST = external, 172.30.0.0/16` and the route resolves to `192.168.0.148`, a private LAN address. Use the in-cluster service URL.
  2. `PATCH .../hooks/{id}` with `config.secret` returns 200 but **does not store the secret**; deliveries arrive unsigned and PaC rejects them. The API never echoes `secret` back, so it fails invisibly. Supply it at `POST` creation time.

### Verified
- `kubeseal --validate` passes against the live controller
- `kustomize build` resolves `b4mad-release-token` into `op1st-gitops`
- no plaintext in the diff

### Still open
`arena-forge-forgejo-{read,write}` and `arena-forge-pipeline-agent` lack `metadata.namespace` and will be sealed for `default` by the next full reseal. Untouched here to keep this reviewable.